### PR TITLE
added support for limiting ag search to file types

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -809,9 +809,9 @@ denoter file/dir is found or uses dumb-jump-default-profile"
 
 (defun dumb-jump-get-ag-type-by-language (language)
   "Returns list of ag type argument for a LANGUAGE"
-  (--map (plist-get it :agtype)
-         (--filter (string= (plist-get it :agtype) language)
-                  dumb-jump-language-file-exts)))
+  (-distinct (--map (plist-get it :agtype)
+                    (--filter (string= (plist-get it :agtype) language)
+                              dumb-jump-language-file-exts))))
 
 (defun dumb-jump-get-rules-by-language (language)
   "Returns a list of rules for the LANGUAGE"

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -776,9 +776,7 @@ denoter file/dir is found or uses dumb-jump-default-profile"
                       (if (s-ends-with? ".gz" cur-file)
                           " --search-zip"
                         "")
-                      (dumb-jump-arg-joiner
-                       "--"
-                       agtypes)))
+                      (s-join "" (--map (format " --%s" it) agtypes))))
          (exclude-args (dumb-jump-arg-joiner "--ignore-dir" (--map (s-replace proj "" it) exclude-paths)))
          (regex-args (format "\"%s\"" (s-join "|" filled-regexes))))
     (if (= (length regexes) 0)

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -810,7 +810,7 @@ denoter file/dir is found or uses dumb-jump-default-profile"
 (defun dumb-jump-get-ag-type-by-language (language)
   "Returns list of ag type argument for a LANGUAGE"
   (-distinct (--map (plist-get it :agtype)
-                    (--filter (string= (plist-get it :agtype) language)
+                    (--filter (string= (plist-get it :language) language)
                               dumb-jump-language-file-exts))))
 
 (defun dumb-jump-get-rules-by-language (language)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -73,7 +73,7 @@
 
 (ert-deftest dumb-jump-generate-ag-command-no-ctx-test ()
   (let ((regexes (dumb-jump-get-contextual-regexes "elisp" nil))
-        (expected "ag --nocolor --nogroup \"\\(defun\\s+tester(?![\\w-])|\\(defvar\\b\\s*tester(?![\\w-])|\\(defcustom\\b\\s*tester(?![\\w-])|\\(setq\\b\\s*tester(?![\\w-])|\\(tester\\s+|\\(defun\\s*.+\\(?\\s*tester(?![\\w-])\\s*\\)?\" ."))
+        (expected "ag --nocolor --nogroup --elisp \"\\(defun\\s+tester(?![\\w-])|\\(defvar\\b\\s*tester(?![\\w-])|\\(defcustom\\b\\s*tester(?![\\w-])|\\(setq\\b\\s*tester(?![\\w-])|\\(tester\\s+|\\(defun\\s*.+\\(?\\s*tester(?![\\w-])\\s*\\)?\" ."))
     (should (string= expected  (dumb-jump-generate-ag-command  "tester" "blah.el" "." regexes "elisp" nil)))))
 
 (ert-deftest dumb-jump-generate-grep-command-no-ctx-funcs-only-test ()


### PR DESCRIPTION
while search for a certain function in a Python file, dumb-jump got me to function with same name in JavaScript file. Hence I added support for limiting search to file types which should speed up searching too.

Corrected the way ag file types are concatenated.
