### PR TITLE
Add ruby's class and module support

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -159,6 +159,14 @@
            :regex "\\bdef\\s+JJJ\\s*\\\("
            :tests ("def test(asdf)" "def test()"))
 
+    (:type "type" :language "ruby"
+           :regex "\\bclass\\s+(?:\\w*::)*JJJ\\s*"
+           :tests ("class Test" "class Foo::Test"))
+
+    (:type "type" :language "ruby"
+           :regex "\\bmodule\\s+(?:\\w*::)*JJJ\\s*"
+           :tests ("module Test" "module Foo::Test"))
+
     ;; scala
     (:type "variable" :language "scala"
            :regex "\\bval\\s*JJJ\\s*=[^=\\n]+" :tests ("val test = 1234") :not ("case test => 1234"))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -159,7 +159,7 @@
 
     (:type "function" :supports ("ag" "grep") :language "ruby"
            :regex "\\bdef\\s+JJJ\\j"
-           :tests ("def test(foo)" "def test()" "def test foo" "def test-foo" "def test; end"))
+           :tests ("def test(foo)" "def test()" "def test foo" "def test; end"))
 
     (:type "type" :supports ("ag") :language "ruby"
            :regex "\\bclass\\s+(?:\\w*::)*JJJ\\j"

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -156,7 +156,7 @@
            :regex "\\s*JJJ\\s*=[^=\\n]+" :tests ("test = 1234") :not ("if test == 1234"))
 
     (:type "function" :language "ruby"
-           :regex "\\bdef\\s*JJJ\\s*\\\("
+           :regex "\\bdef\\s+JJJ\\s*\\\("
            :tests ("def test(asdf)" "def test()"))
 
     ;; scala

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -169,14 +169,6 @@
            :regex "\\bmodule\\s+(?:\\w*::)*JJJ\\b"
            :tests ("module Test" "module Foo::Test"))
 
-    (:type "type" :language "ruby"
-           :regex "\\bclass\\s+(?:\\w*::)*JJJ\\s*"
-           :tests ("class Test" "class Foo::Test"))
-
-    (:type "type" :language "ruby"
-           :regex "\\bmodule\\s+(?:\\w*::)*JJJ\\s*"
-           :tests ("module Test" "module Foo::Test"))
-
     ;; scala
     (:type "variable" :language "scala"
            :regex "\\bval\\s*JJJ\\s*=[^=\\n]+" :tests ("val test = 1234") :not ("case test => 1234"))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -153,11 +153,21 @@
 
     ;; ruby
     (:type "variable" :language "ruby"
-           :regex "\\s*JJJ\\s*=[^=\\n]+" :tests ("test = 1234") :not ("if test == 1234"))
+           :regex "\\s*JJJ\\s*=[^=\\n]+"
+           :tests ("test = 1234")
+           :not ("if test == 1234"))
 
     (:type "function" :language "ruby"
-           :regex "\\bdef\\s+JJJ\\s*\\\("
-           :tests ("def test(asdf)" "def test()"))
+           :regex "\\bdef\\s+JJJ\\b"
+           :tests ("def test(foo)" "def test()" "def test foo" "def test" "def test; end"))
+
+    (:type "type" :language "ruby"
+           :regex "\\bclass\\s+(?:\\w*::)*JJJ\\b"
+           :tests ("class Test" "class Foo::Test"))
+
+    (:type "type" :language "ruby"
+           :regex "\\bmodule\\s+(?:\\w*::)*JJJ\\b"
+           :tests ("module Test" "module Foo::Test"))
 
     (:type "type" :language "ruby"
            :regex "\\bclass\\s+(?:\\w*::)*JJJ\\s*"


### PR DESCRIPTION
Adds support for the following constructions in Ruby:

* `class Foo`

* `module Foo`

This depends on #23 since grep does not support these regexes