### PR TITLE
Add extra matches for Clojure

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -134,10 +134,42 @@
            :not ("(defun blah (test-1)" "(defun blah (test-2 blah)" "(defun (blah test-3)"))
 
     ;; clojure
-    (:type "function" :language "clojure" :regex "\\\(defn-?\\s+JJJ\\j"
+    (:type "variable" :language "clojure"
+           :regex "\\\(def\\s+JJJ\\j"
+           :tests ("(def test (foo)" "(def test-foo (bar)"))
+
+    (:type "function" :language "clojure"
            ;; \\j usage see `dumb-jump-ag-word-boundary`
-           :tests ("(defn test (blah)" "(defn test\n" "(defn- test (blah)" "(defn- test\n")
-           :not ("(defn test-asdf (blah)" "(defn test-blah\n" "(defn- test-asdf (blah)" "(defn- test-blah\n"))
+           :regex "\\\(defn-?\\s+JJJ\\j"
+           :tests ("(defn test [foo]" "(defn- test [foo]" "(defn test-foo [bar]" "(defn- test-foo [bar]"))
+
+    (:type "function" :language "clojure"
+           :regex "\\\(defmacro\\s+JJJ\\j"
+           :tests ("(defmacro test [foo]" "(defmacro test-foo [bar]"))
+
+    (:type "type" :language "clojure"
+           :regex "\\\(deftype\\s+JJJ\\j"
+           :tests ("(deftype Test [foo]" "(deftype Test-foo [bar]"))
+
+    (:type "type" :language "clojure"
+           :regex "\\\(defmulti\\s+JJJ\\j"
+           :tests ("(defmulti test fn" "(defmulti test-foo fn"))
+
+    (:type "type" :language "clojure"
+           :regex "\\\(defmethod\\s+JJJ\\j"
+           :tests ("(defmethod test Type" "(defmethod test-foo Type"))
+
+    (:type "type" :language "clojure"
+           :regex "\\\(definterface\\s+JJJ\\j"
+           :tests ("(definterface Itest (foo)" "(definterface Itest-foo (bar)"))
+
+    (:type "type" :language "clojure"
+           :regex "\\\(defprotocol\\s+JJJ\\j"
+           :tests ("(defprotocol Test (foo)" "(defprotocol Test-foo (bar)"))
+
+    (:type "type" :language "clojure"
+           :regex "\\\(defrecord\\s+JJJ\\j"
+           :tests ("(defrecord Test [foo]" "(defrecord Test-foo [bar]"))
 
     ;; python
     (:type "variable" :language "python"

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -116,20 +116,20 @@
            :tests ("(defun test (blah)" "(defun test\n") :not ("(defun test-asdf (blah)" "(defun test-blah\n"))
 
     (:type "variable" :supports ("ag" "grep") :language "elisp"
-           :regex "\\\(defvar\\b\\s+JJJ\\j" :tests ("(defvar test " "(defvar test\n"))
+           :regex "\\\(defvar\\b\\s*JJJ\\j" :tests ("(defvar test " "(defvar test\n"))
 
     (:type "variable" :supports ("ag" "grep") :language "elisp"
-           :regex "\\\(defcustom\\b\\s+JJJ\\j" :tests ("(defcustom test " "(defcustom test\n"))
+           :regex "\\\(defcustom\\b\\s*JJJ\\j" :tests ("(defcustom test " "(defcustom test\n"))
 
     (:type "variable" :supports ("ag" "grep") :language "elisp"
-           :regex "\\\(setq\\b\\s+JJJ\\j" :tests ("(setq test 123)") :not ("setq test-blah 123)"))
+           :regex "\\\(setq\\b\\s*JJJ\\j" :tests ("(setq test 123)") :not ("setq test-blah 123)"))
 
     (:type "variable" :supports ("ag" "grep") :language "elisp"
            :regex "\\\(JJJ\\s+" :tests ("(let ((test 123)))") :not ("(let ((test-2 123)))"))
 
     ;; variable in method signature
     (:type "variable" :supports ("ag" "grep") :language "elisp"
-           :regex "\\\(defun\\s+.+\\\(?\\s*JJJ\\j\\s*\\\)?"
+           :regex "\\(defun\\s*.+\\\(?\\s*JJJ\\j\\s*\\\)?"
            :tests ("(defun blah (test)" "(defun blah (test blah)" "(defun (blah test)")
            :not ("(defun blah (test-1)" "(defun blah (test-2 blah)" "(defun (blah test-3)"))
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -135,39 +135,39 @@
 
     ;; clojure
     (:type "variable" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(def\\s+JJJ\\j"
+           :regex "\\(def\\s+JJJ\\j"
            :tests ("(def test (foo)"))
 
     (:type "function" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(defn-?\\s+JJJ\\j"
+           :regex "\\(defn-?\\s+JJJ\\j"
            :tests ("(defn test [foo]" "(defn- test [foo]"))
 
     (:type "function" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(defmacro\\s+JJJ\\j"
+           :regex "\\(defmacro\\s+JJJ\\j"
            :tests ("(defmacro test [foo]"))
 
     (:type "type" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(deftype\\s+JJJ\\j"
+           :regex "\\(deftype\\s+JJJ\\j"
            :tests ("(deftype test [foo]"))
 
     (:type "type" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(defmulti\\s+JJJ\\j"
+           :regex "\\(defmulti\\s+JJJ\\j"
            :tests ("(defmulti test fn"))
 
     (:type "type" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(defmethod\\s+JJJ\\j"
+           :regex "\\(defmethod\\s+JJJ\\j"
            :tests ("(defmethod test type"))
 
     (:type "type" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(definterface\\s+JJJ\\j"
+           :regex "\\(definterface\\s+JJJ\\j"
            :tests ("(definterface test (foo)"))
 
     (:type "type" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(defprotocol\\s+JJJ\\j"
+           :regex "\\(defprotocol\\s+JJJ\\j"
            :tests ("(defprotocol test (foo)"))
 
     (:type "type" :supports ("ag" "grep") :language "clojure"
-           :regex "\\\(defrecord\\s+JJJ\\j"
+           :regex "\\(defrecord\\s+JJJ\\j"
            :tests ("(defrecord test [foo]"))
 
     ;; python

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -129,7 +129,7 @@
 
     ;; variable in method signature
     (:type "variable" :language "elisp"
-           :regex "\\(defun\\s*.+\\\(?\\s*JJJ\\j\\s*\\\)?"
+           :regex "\\\(defun\\s*.+\\\(?\\s*JJJ\\j\\s*\\\)?"
            :tests ("(defun blah (test)" "(defun blah (test blah)" "(defun (blah test)")
            :not ("(defun blah (test-1)" "(defun blah (test-2 blah)" "(defun (blah test-3)"))
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -135,41 +135,40 @@
 
     ;; clojure
     (:type "variable" :language "clojure"
-           :regex "\\\(def\\s+JJJ\\j"
-           :tests ("(def test (foo)" "(def test-foo (bar)"))
+           :regex "\\\(def\\s+JJJ\\b"
+           :tests ("(def test (foo)"))
 
     (:type "function" :language "clojure"
-           ;; \\j usage see `dumb-jump-ag-word-boundary`
-           :regex "\\\(defn-?\\s+JJJ\\j"
-           :tests ("(defn test [foo]" "(defn- test [foo]" "(defn test-foo [bar]" "(defn- test-foo [bar]"))
+           :regex "\\\(defn-?\\s+JJJ\\b"
+           :tests ("(defn test [foo]" "(defn- test [foo]"))
 
     (:type "function" :language "clojure"
-           :regex "\\\(defmacro\\s+JJJ\\j"
-           :tests ("(defmacro test [foo]" "(defmacro test-foo [bar]"))
+           :regex "\\\(defmacro\\s+JJJ\\b"
+           :tests ("(defmacro test [foo]"))
 
     (:type "type" :language "clojure"
-           :regex "\\\(deftype\\s+JJJ\\j"
-           :tests ("(deftype Test [foo]" "(deftype Test-foo [bar]"))
+           :regex "\\\(deftype\\s+JJJ\\b"
+           :tests ("(deftype Test [foo]"))
 
     (:type "type" :language "clojure"
-           :regex "\\\(defmulti\\s+JJJ\\j"
-           :tests ("(defmulti test fn" "(defmulti test-foo fn"))
+           :regex "\\\(defmulti\\s+JJJ\\b"
+           :tests ("(defmulti test fn"))
 
     (:type "type" :language "clojure"
-           :regex "\\\(defmethod\\s+JJJ\\j"
-           :tests ("(defmethod test Type" "(defmethod test-foo Type"))
+           :regex "\\\(defmethod\\s+JJJ\\b"
+           :tests ("(defmethod test Type"))
 
     (:type "type" :language "clojure"
-           :regex "\\\(definterface\\s+JJJ\\j"
-           :tests ("(definterface Itest (foo)" "(definterface Itest-foo (bar)"))
+           :regex "\\\(definterface\\s+JJJ\\b"
+           :tests ("(definterface Test (foo)"))
 
     (:type "type" :language "clojure"
-           :regex "\\\(defprotocol\\s+JJJ\\j"
-           :tests ("(defprotocol Test (foo)" "(defprotocol Test-foo (bar)"))
+           :regex "\\\(defprotocol\\s+JJJ\\b"
+           :tests ("(defprotocol Test (foo)"))
 
     (:type "type" :language "clojure"
-           :regex "\\\(defrecord\\s+JJJ\\j"
-           :tests ("(defrecord Test [foo]" "(defrecord Test-foo [bar]"))
+           :regex "\\\(defrecord\\s+JJJ\\b"
+           :tests ("(defrecord Test [foo]"))
 
     ;; python
     (:type "variable" :language "python"

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -145,7 +145,7 @@
   (let* ((dumb-jump-force-grep t)
          (regexes (dumb-jump-get-contextual-regexes "elisp" nil))
          (results (dumb-jump-run-command "another-fake-function" test-data-dir-elisp regexes "" ""  "blah.el" 3))
-         (first-result (car results)))
+        (first-result (car results)))
     (should (s-contains? "/fake.el" (plist-get first-result :path)))
     (should (= (plist-get first-result :line) 6))))
 

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -68,12 +68,12 @@
 
 (ert-deftest dumb-jump-generate-grep-command-no-ctx-test ()
   (let ((regexes (dumb-jump-get-contextual-regexes "elisp" nil))
-        (expected "LANG=C grep -REn --include \\*.el --include \\*.el.gz -e '\\(defun\\s+tester($|[^\\w-])' -e '\\(defvar\\b\\s+tester($|[^\\w-])' -e '\\(defcustom\\b\\s+tester($|[^\\w-])' -e '\\(setq\\b\\s+tester($|[^\\w-])' -e '\\(tester\\s+' -e '\\(defun\\s+.+\\(?\\s*tester($|[^\\w-])\\s*\\)?' ."))
+        (expected "LANG=C grep -REn --include \\*.el --include \\*.el.gz -e '\\(defun\\s+tester($|[^\\w-])' -e '\\(defvar\\b\\s*tester($|[^\\w-])' -e '\\(defcustom\\b\\s*tester($|[^\\w-])' -e '\\(setq\\b\\s*tester($|[^\\w-])' -e '\\(tester\\s+' -e '\\(defun\\s*.+\\(?\\s*tester($|[^\\w-])\\s*\\)?' ."))
     (should (string= expected  (dumb-jump-generate-grep-command  "tester" "blah.el" "." regexes "elisp" nil)))))
 
 (ert-deftest dumb-jump-generate-ag-command-no-ctx-test ()
   (let ((regexes (dumb-jump-get-contextual-regexes "elisp" nil))
-        (expected "ag --nocolor --nogroup --elisp \"\\(defun\\s+tester(?![\\w-])|\\(defvar\\b\\s+tester(?![\\w-])|\\(defcustom\\b\\s+tester(?![\\w-])|\\(setq\\b\\s+tester(?![\\w-])|\\(tester\\s+|\\(defun\\s+.+\\(?\\s*tester(?![\\w-])\\s*\\)?\" ."))
+        (expected "ag --nocolor --nogroup --elisp \"\\(defun\\s+tester(?![\\w-])|\\(defvar\\b\\s*tester(?![\\w-])|\\(defcustom\\b\\s*tester(?![\\w-])|\\(setq\\b\\s*tester(?![\\w-])|\\(tester\\s+|\\(defun\\s*.+\\(?\\s*tester(?![\\w-])\\s*\\)?\" ."))
     (should (string= expected  (dumb-jump-generate-ag-command  "tester" "blah.el" "." regexes "elisp" nil)))))
 
 (ert-deftest dumb-jump-generate-grep-command-no-ctx-funcs-only-test ()
@@ -96,7 +96,7 @@
   (let* ((ctx-type (dumb-jump-get-ctx-type-by-language "elisp" '(:left "(" :right nil)))
          (dumb-jump-ignore-context t)
          (regexes (dumb-jump-get-contextual-regexes "elisp" ctx-type))
-         (expected "LANG=C grep -REn -e '\\(defun\\s+tester($|[^\\w-])' -e '\\(defvar\\b\\s+tester($|[^\\w-])' -e '\\(defcustom\\b\\s+tester($|[^\\w-])' -e '\\(setq\\b\\s+tester($|[^\\w-])' -e '\\(tester\\s+' -e '\\(defun\\s+.+\\(?\\s*tester($|[^\\w-])\\s*\\)?' ."))
+         (expected "LANG=C grep -REn -e '\\(defun\\s+tester($|[^\\w-])' -e '\\(defvar\\b\\s*tester($|[^\\w-])' -e '\\(defcustom\\b\\s*tester($|[^\\w-])' -e '\\(setq\\b\\s*tester($|[^\\w-])' -e '\\(tester\\s+' -e '\\(defun\\s*.+\\(?\\s*tester($|[^\\w-])\\s*\\)?' ."))
 
     ;; the point context being passed is ignored so ALL should return
     (should (string= expected  (dumb-jump-generate-grep-command "tester" "blah.el" "." regexes "" nil)))))


### PR DESCRIPTION
Adds support for the following constructions in Clojure:

* `(def foo`

* `(defn foo` / `(defn- foo`

* `(defmacro foo`

* `(deftype foo`

* `(defmulti foo`

* `(defmethod foo`

* `(definterface foo`

* `(defprotocol foo`

* `(defrecord foo`