### PR TITLE
Add haml and slim to Ruby language files

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -666,6 +666,8 @@
     (:language "php" :ext "php" :agtype "php")
     (:language "php" :ext "inc" :agtype "php")
     (:language "ruby" :ext "rb" :agtype "ruby")
+    (:language "ruby" :ext "haml" :agtype "ruby")
+    (:language "ruby" :ext "slim" :agtype "ruby")
     (:language "scala" :ext "scala" :agtype "scala")
     (:language "shell" :ext "sh" :agtype "shell")
     (:language "shell" :ext "bash" :agtype "shell")


### PR DESCRIPTION
I don't know if this is a good idea, since technically they aren't ruby files, but functions used in them can only be from ruby files, some of which may be helpers defined in the project. This works for me but I'm not sure if it's generally a good idea, but it seems like if js and jsx can share a language definition, perhaps so can ruby and its templating languages? Feedback appreciated!