### PR TITLE
Add `dumb-jump-selector` for `helm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Dumb Jump will automatically look for a project root. If it's not finding one th
 * To support more languages and/or definition types use `add-to-list` on `dumb-jump-find-rules` (see source code).
 * `(add-hook 'dumb-jump-after-jump-hook 'some-function)` to execute code after you jump
 * `(setq dumb-jump-selector 'ivy)` to use [ivy](https://github.com/abo-abo/swiper#ivy) instead of the default popup for multiple options.
+* `(setq dumb-jump-selector 'helm)` to use [helm](https://github.com/emacs-helm/helm) instead of the default popup for multiple options.
 
 ##### `use-package` example configuration.
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -926,7 +926,7 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
           (dumb-jump-result-follow result))))
 
 (defun dumb-jump-prompt-user-for-choice (proj results)
-  "Put a PROJ's list of RESULTS in a 'popup-menu' (or ivy) for user to select.  Filters PROJ path from files for display."
+  "Put a PROJ's list of RESULTS in a 'popup-menu' (or helm/ivy) for user to select.  Filters PROJ path from files for display."
   (let* ((choices (-map (lambda (result)
                           (format "%s:%s %s"
                                   (s-replace proj "" (plist-get result :path))
@@ -937,8 +937,7 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
      ((and (eq dumb-jump-selector 'ivy) (fboundp 'ivy-read))
       (dumb-jump-to-selected results choices (ivy-read "Jump to: " choices)))
      ((and (eq dumb-jump-selector 'helm) (fboundp 'helm))
-      (dumb-jump-to-selected results choices (helm :sources (helm-build-sync-source "Jump to:" :candidates choices :fuzzy-match t)
-                                                   :buffer "*helm dumb-jump*")))
+      (dumb-jump-to-selected results choices (helm :sources (helm-build-sync-source "Jump to: " :candidates choices))))
      (t
       (dumb-jump-to-selected results choices (popup-menu* choices))))))
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -3,7 +3,6 @@
 ;; Copyright (C) 2015-2016 jack angers
 ;; Author: jack angers
 ;; Version: 0.4.3
-;; Package-Version: 20161126.2045
 ;; Package-Requires: ((emacs "24.3") (f "0.17.3") (s "1.11.0") (dash "2.9.0") (popup "0.5.3"))
 ;; Keywords: programming
 
@@ -938,9 +937,7 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
      ((and (eq dumb-jump-selector 'ivy) (fboundp 'ivy-read))
       (dumb-jump-to-selected results choices (ivy-read "Jump to: " choices)))
      ((and (eq dumb-jump-selector 'helm) (fboundp 'helm))
-      (dumb-jump-to-selected results choices (helm :sources (helm-build-sync-source "Jump to:"
-                                                              :candidates choices
-                                                              :fuzzy-match t)
+      (dumb-jump-to-selected results choices (helm :sources (helm-build-sync-source "Jump to:" :candidates choices :fuzzy-match t)
                                                    :buffer "*helm dumb-jump*")))
      (t
       (dumb-jump-to-selected results choices (popup-menu* choices))))))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -332,6 +332,16 @@
      (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
+(ert-deftest dumb-jump-prompt-user-for-choice-correct-helm-test ()
+  (let* ((dumb-jump-selector 'helm)
+         (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")
+                    (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
+    (with-mock
+     (mock (helm-build-sync-source * :candidates *))
+     (mock (helm * *) => "/test2.txt:52 var thing = function()")
+     (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
+     (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
+
 (ert-deftest dumb-jump-prompt-user-for-choice-correct-ivy-test ()
   (let* ((dumb-jump-selector 'ivy)
          (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")


### PR DESCRIPTION
This commit adds an additional option for `dumb-jumb-selector` for using Helm to browse multi-choice jumps. A `if` clause has been changed to a `cond` to accomodate the additional rule in a more elegant manner, but the code is otherwise fairly similar to work done for `ivy` support.

Tests are forthcoming.

P.S.: Mainly opening this to test the waters, this is pretty much my first foray into Lisp so feel free to comment/berate. Not sure if the lack of `helm` suport is on purpose or if nobody did the work, but thinking it may be useful for Spacemacs users. 

P.P.S.: As mentioned above, I'll be adding tests in a subsequent commit once I figure out how to do it. ;)