### PR TITLE
Fixed C++ function regexp for template arguments (#87)

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -987,7 +987,7 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
 (defun dumb-jump-get-results ()
   "Run dumb-jump-fetch-results if searcher installed, buffer is saved, and there's a symbol under point."
   (cond
-   ((not (or (dumb-jump-rg-installed?) (dumb-jump-ag-installed?) (dumb-jump-grep-installed?)))
+   ((not (or (dumb-jump-ag-installed?) (dumb-jump-rg-installed?) (dumb-jump-grep-installed?)))
     (dumb-jump-issue-result "nogrep"))
    ((or (string= (buffer-name) "*shell*")
         (string= (buffer-name) "*eshell*"))
@@ -1320,10 +1320,10 @@ Ffrom the ROOT project CONFIG-FILE."
   (and (not dumb-jump-force-grep) (dumb-jump-rg-installed?)))
 
 (defun dumb-jump-pick-grep-variant (parse)
-  (cond ((dumb-jump-use-rg?)
-         (if parse #'dumb-jump-parse-rg-response #'dumb-jump-generate-rg-command))
-        ((dumb-jump-use-ag?)
+  (cond ((dumb-jump-use-ag?)
          (if parse #'dumb-jump-parse-ag-response #'dumb-jump-generate-ag-command))
+	((dumb-jump-use-rg?)
+         (if parse #'dumb-jump-parse-rg-response #'dumb-jump-generate-rg-command))
         ((eq (dumb-jump-grep-installed?) 'gnu)
          (if parse #'dumb-jump-parse-grep-response #'dumb-jump-generate-gnu-grep-command))
         (t

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -188,7 +188,7 @@
 
     ;; c++
     (:type "function" :supports ("ag" "rg") :language "c++"
-           :regex "\\bJJJ(\\s|\\))*\\((\\w|[,&*.]|\\s)*(\\))\\s*(const|->|\\{|$)|typedef\\s+(\\w|[(*]|\\s)+JJJ(\\)|\\s)*\\("
+           :regex "\\bJJJ(\\s|\\))*\\((\\w|[,&*.<>]|\\s)*(\\))\\s*(const|->|\\{|$)|typedef\\s+(\\w|[(*]|\\s)+JJJ(\\)|\\s)*\\("
            :tests ("int test(){" "my_struct (*test)(int a, int b){" "auto MyClass::test ( Builder& reference, ) -> decltype( builder.func() ) {" "int test( int *random_argument) const {" "test::test() {" "typedef int (*test)(int);")
            :not ("return test();)" "int test(a, b);" "if( test() ) {" "else test();"))
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1155,7 +1155,29 @@ When USE-TOOLTIP is t a tooltip jump preview will show instead."
 
 (defcustom dumb-jump-language-comments
   '((:comment "//" :language "c++")
-    (:comment ";" :language "elisp"))
+    (:comment ";" :language "elisp")
+    (:comment "//" :language "javascript")
+    (:comment "--" :language "haskell")
+    (:comment "--" :language "lua")
+    (:comment "//" :language "rust")
+    (:comment "//" :language "objc")
+    (:comment "//" :language "csharp")
+    (:comment "//" :language "java")
+    (:comment ";" :language "clojure")
+    (:comment "#" :language "coffeescript")
+    (:comment "//" :language "faust")
+    (:comment "!" :language "fortran")
+    (:comment "//" :language "go")
+    (:comment ";" :language "lisp")
+    (:comment "#" :language "perl")
+    (:comment "//" :language "php")
+    (:comment "#" :language "python")
+    (:comment "#" :language "r")
+    (:comment "#" :language "ruby")
+    (:comment "//" :language "scala")
+    (:comment ";" :language "scheme")
+    (:comment "#" :language "shell")
+    (:comment "//" :language "swift"))
   "List of one-line comments organized by language."
   :group 'dumb-jump
   :type

--- a/test/data/proj1/src/cpp/issue-87.cpp
+++ b/test/data/proj1/src/cpp/issue-87.cpp
@@ -1,0 +1,20 @@
+// --------------------------------------------------------------------------
+//  CAdaptiveCaching::_processPixelOverlap()
+// --------------------------------------------------------------------------
+template<class TRecord,class TContribArray>
+int
+CAdaptiveCaching::_processPixelOverlap(const CHitInfoLite &hit,
+                                       const float *directIllum,
+                                       const float  thresholdElevation,
+                                       TContribArray &carray,
+                                       CRCOctree<TRecord> *octree)
+{
+}
+
+if(_adaptive && !pixContribs.ProcessPixelDone())
+  {
+    _extrapolateRadianceValid(pixContribs,hit);
+    _processPixelOverlap(hit,hit.directIllum.data(),
+                         1/*thrElevImage[idx]*/,pixContribs,GetOctree<TRecord>());
+    pixContribs.SetProcessPixelDone();
+  }

--- a/test/data/proj1/src/cpp/test.cpp
+++ b/test/data/proj1/src/cpp/test.cpp
@@ -1,0 +1,10 @@
+class Foo {
+public:
+  int bar(int val) {
+    return val;
+  }
+};
+
+int main() {
+  return Foo::bar(42);
+}

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -834,3 +834,35 @@
       (with-mock
        (mock (dumb-jump-goto-file-line * 37 6))
        (should (string= js-file (dumb-jump-go)))))))
+
+;; c++ tests
+
+(ert-deftest dumb-jump-cpp-test1 ()
+  (let ((cpp-file (f-join test-data-dir-proj1 "src" "cpp" "test.cpp")))
+    (with-current-buffer (find-file-noselect cpp-file t)
+      (goto-char (point-min))
+      (forward-line 8)
+      (forward-char 14)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 3 6))
+       (should (string= cpp-file (dumb-jump-go)))))))
+
+(ert-deftest dumb-jump-cpp-test2 ()
+  (let ((cpp-file (f-join test-data-dir-proj1 "src" "cpp" "test.cpp")))
+    (with-current-buffer (find-file-noselect cpp-file t)
+      (goto-char (point-min))
+      (forward-line 8)
+      (forward-char 9)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 1 6))
+       (should (string= cpp-file (dumb-jump-go)))))))
+
+(ert-deftest dumb-jump-cpp-issue87 ()
+  (let ((cpp-file (f-join test-data-dir-proj1 "src" "cpp" "issue-87.cpp")))
+    (with-current-buffer (find-file-noselect cpp-file t)
+      (goto-char (point-min))
+      (forward-line 16)
+      (forward-char 12)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 6 18))
+       (should (string= cpp-file (dumb-jump-go)))))))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -259,30 +259,34 @@
     (dumb-jump-output-rule-test-failures rule-failures)
     (should (= (length rule-failures) 0))))
 
-(ert-deftest dumb-jump-test-ag-rules-test ()
-  (let ((rule-failures (dumb-jump-test-ag-rules)))
-    (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+(when (dumb-jump-ag-installed?)
+  (ert-deftest dumb-jump-test-ag-rules-test ()
+    (let ((rule-failures (dumb-jump-test-ag-rules)))
+      (dumb-jump-output-rule-test-failures rule-failures)
+      (should (= (length rule-failures) 0)))))
 
-(ert-deftest dumb-jump-test-rg-rules-test ()
-  (let ((rule-failures (dumb-jump-test-rg-rules)))
-    (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+(when (dumb-jump-rg-installed?)
+  (ert-deftest dumb-jump-test-rg-rules-test ()
+    (let ((rule-failures (dumb-jump-test-rg-rules)))
+      (dumb-jump-output-rule-test-failures rule-failures)
+      (should (= (length rule-failures) 0)))))
 
 (ert-deftest dumb-jump-test-rules-not-test () ;; :not tests
   (let ((rule-failures (dumb-jump-test-rules t)))
     (dumb-jump-output-rule-test-failures rule-failures)
     (should (= (length rule-failures) 0))))
 
-(ert-deftest dumb-jump-test-ag-rules-not-test () ;; :not tests
-  (let ((rule-failures (dumb-jump-test-ag-rules t)))
+(when (dumb-jump-ag-installed?)
+  (ert-deftest dumb-jump-test-ag-rules-not-test () ;; :not tests
+    (let ((rule-failures (dumb-jump-test-ag-rules t)))
     (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+    (should (= (length rule-failures) 0)))))
 
-(ert-deftest dumb-jump-test-rg-rules-not-test () ;; :not tests
-  (let ((rule-failures (dumb-jump-test-rg-rules t)))
-    (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+(when (dumb-jump-rg-installed?)
+  (ert-deftest dumb-jump-test-rg-rules-not-test () ;; :not tests
+    (let ((rule-failures (dumb-jump-test-rg-rules t)))
+      (dumb-jump-output-rule-test-failures rule-failures)
+      (should (= (length rule-failures) 0)))))
 
 (ert-deftest dumb-jump-test-rules-fail-test ()
   (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
@@ -291,19 +295,21 @@
     ;(message "%s" (prin1-to-string rule-failures))
     (should (= (length rule-failures) 1))))
 
-(ert-deftest dumb-jump-test-ag-rules-fail-test ()
-  (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
-         (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
-         (rule-failures (dumb-jump-test-ag-rules)))
-    ;(message "%s" (prin1-to-string rule-failures))
-    (should (= (length rule-failures) 1))))
+(when (dumb-jump-ag-installed?)
+  (ert-deftest dumb-jump-test-ag-rules-fail-test ()
+    (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
+	   (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
+	   (rule-failures (dumb-jump-test-ag-rules)))
+					;(message "%s" (prin1-to-string rule-failures))
+      (should (= (length rule-failures) 1)))))
 
-(ert-deftest dumb-jump-test-rg-rules-fail-test ()
-  (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
-         (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
-         (rule-failures (dumb-jump-test-rg-rules)))
-    ;(message "%s" (prin1-to-string rule-failures))
-    (should (= (length rule-failures) 1))))
+(when (dumb-jump-rg-installed?)
+  (ert-deftest dumb-jump-test-rg-rules-fail-test ()
+    (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
+	   (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
+	   (rule-failures (dumb-jump-test-rg-rules)))
+					;(message "%s" (prin1-to-string rule-failures))
+      (should (= (length rule-failures) 1)))))
 
 (ert-deftest dumb-jump-match-test ()
   (should (not (dumb-jump-re-match nil "asdf")))


### PR DESCRIPTION
I fixed C++ function regexp for template arguments and added a few C++ tests.

Test file "test/data/proj1/src/cpp/issue-87.cpp" verifies the fix of issue #87.

"Ran 106 tests, 106 results as expected (2017-03-10 23:06:41+0100)"