### PR TITLE
Project root detection: Ignore sub-folders using '.dumbjumpignore' (#36)

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -949,10 +949,14 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
       dumb-jump-default-project)))
 
 (defun dumb-jump-get-config (dir)
-  "If a project denoter is in DIR then return it.  Otherwise nil."
-  (car (--filter
+  "If a project denoter is in DIR then return it, otherwise
+nil. However, if DIR contains a `.dumbjumpignore' it returns nil
+to keep looking for another root."
+  (if (f-exists? (f-join dir ".dumbjumpignore"))
+      nil
+    (car (--filter
           (f-exists? (f-join dir it))
-        dumb-jump-project-denoters)))
+          dumb-jump-project-denoters))))
 
 (defun dumb-jump-get-language (file)
   "Get language from FILE extension and then fallback to using 'major-mode' name."

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -987,7 +987,7 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
 (defun dumb-jump-get-results ()
   "Run dumb-jump-fetch-results if searcher installed, buffer is saved, and there's a symbol under point."
   (cond
-   ((not (or (dumb-jump-rg-installed?) (dumb-jump-ag-installed?) (dumb-jump-grep-installed?)))
+   ((not (or (dumb-jump-ag-installed?) (dumb-jump-rg-installed?) (dumb-jump-grep-installed?)))
     (dumb-jump-issue-result "nogrep"))
    ((or (string= (buffer-name) "*shell*")
         (string= (buffer-name) "*eshell*"))
@@ -1320,10 +1320,10 @@ Ffrom the ROOT project CONFIG-FILE."
   (and (not dumb-jump-force-grep) (dumb-jump-rg-installed?)))
 
 (defun dumb-jump-pick-grep-variant (parse)
-  (cond ((dumb-jump-use-rg?)
-         (if parse #'dumb-jump-parse-rg-response #'dumb-jump-generate-rg-command))
-        ((dumb-jump-use-ag?)
+  (cond ((dumb-jump-use-ag?)
          (if parse #'dumb-jump-parse-ag-response #'dumb-jump-generate-ag-command))
+	((dumb-jump-use-rg?)
+         (if parse #'dumb-jump-parse-rg-response #'dumb-jump-generate-rg-command))
         ((eq (dumb-jump-grep-installed?) 'gnu)
          (if parse #'dumb-jump-parse-grep-response #'dumb-jump-generate-gnu-grep-command))
         (t

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -188,7 +188,7 @@
 
     ;; c++
     (:type "function" :supports ("ag" "rg") :language "c++"
-           :regex "\\bJJJ(\\s|\\))*\\((\\w|[,&*.]|\\s)*(\\))\\s*(const|->|\\{|$)|typedef\\s+(\\w|[(*]|\\s)+JJJ(\\)|\\s)*\\("
+           :regex "\\bJJJ(\\s|\\))*\\((\\w|[,&*.<>]|\\s)*(\\))\\s*(const|->|\\{|$)|typedef\\s+(\\w|[(*]|\\s)+JJJ(\\)|\\s)*\\("
            :tests ("int test(){" "my_struct (*test)(int a, int b){" "auto MyClass::test ( Builder& reference, ) -> decltype( builder.func() ) {" "int test( int *random_argument) const {" "test::test() {" "typedef int (*test)(int);")
            :not ("return test();)" "int test(a, b);" "if( test() ) {" "else test();"))
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1155,7 +1155,29 @@ When USE-TOOLTIP is t a tooltip jump preview will show instead."
 
 (defcustom dumb-jump-language-comments
   '((:comment "//" :language "c++")
-    (:comment ";" :language "elisp"))
+    (:comment ";" :language "elisp")
+    (:comment "//" :language "javascript")
+    (:comment "--" :language "haskell")
+    (:comment "--" :language "lua")
+    (:comment "//" :language "rust")
+    (:comment "//" :language "objc")
+    (:comment "//" :language "csharp")
+    (:comment "//" :language "java")
+    (:comment ";" :language "clojure")
+    (:comment "#" :language "coffeescript")
+    (:comment "//" :language "faust")
+    (:comment "!" :language "fortran")
+    (:comment "//" :language "go")
+    (:comment ";" :language "lisp")
+    (:comment "#" :language "perl")
+    (:comment "//" :language "php")
+    (:comment "#" :language "python")
+    (:comment "#" :language "r")
+    (:comment "#" :language "ruby")
+    (:comment "//" :language "scala")
+    (:comment ";" :language "scheme")
+    (:comment "#" :language "shell")
+    (:comment "//" :language "swift"))
   "List of one-line comments organized by language."
   :group 'dumb-jump
   :type

--- a/test/data/multiproj/subproj1/main.cc
+++ b/test/data/multiproj/subproj1/main.cc
@@ -1,0 +1,5 @@
+#include "../subproj2/header.h"
+
+int main(int argc, char **argv) {
+  return Awesome::magic();
+}

--- a/test/data/multiproj/subproj2/header.h
+++ b/test/data/multiproj/subproj2/header.h
@@ -1,0 +1,9 @@
+#ifndef TEST_DATA_MULTIPROJ_SUBPROJ2_HEADER_H
+#define TEST_DATA_MULTIPROJ_SUBPROJ2_HEADER_H
+
+class Awesome {
+public:
+  int magic() { return 42; }
+};
+
+#endif // TEST_DATA_MULTIPROJ_SUBPROJ2_HEADER_H

--- a/test/data/proj1/src/cpp/issue-87.cpp
+++ b/test/data/proj1/src/cpp/issue-87.cpp
@@ -1,0 +1,20 @@
+// --------------------------------------------------------------------------
+//  CAdaptiveCaching::_processPixelOverlap()
+// --------------------------------------------------------------------------
+template<class TRecord,class TContribArray>
+int
+CAdaptiveCaching::_processPixelOverlap(const CHitInfoLite &hit,
+                                       const float *directIllum,
+                                       const float  thresholdElevation,
+                                       TContribArray &carray,
+                                       CRCOctree<TRecord> *octree)
+{
+}
+
+if(_adaptive && !pixContribs.ProcessPixelDone())
+  {
+    _extrapolateRadianceValid(pixContribs,hit);
+    _processPixelOverlap(hit,hit.directIllum.data(),
+                         1/*thrElevImage[idx]*/,pixContribs,GetOctree<TRecord>());
+    pixContribs.SetProcessPixelDone();
+  }

--- a/test/data/proj1/src/cpp/test.cpp
+++ b/test/data/proj1/src/cpp/test.cpp
@@ -1,0 +1,10 @@
+class Foo {
+public:
+  int bar(int val) {
+    return val;
+  }
+};
+
+int main() {
+  return Foo::bar(42);
+}

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -834,3 +834,35 @@
       (with-mock
        (mock (dumb-jump-goto-file-line * 37 6))
        (should (string= js-file (dumb-jump-go)))))))
+
+;; c++ tests
+
+(ert-deftest dumb-jump-cpp-test1 ()
+  (let ((cpp-file (f-join test-data-dir-proj1 "src" "cpp" "test.cpp")))
+    (with-current-buffer (find-file-noselect cpp-file t)
+      (goto-char (point-min))
+      (forward-line 8)
+      (forward-char 14)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 3 6))
+       (should (string= cpp-file (dumb-jump-go)))))))
+
+(ert-deftest dumb-jump-cpp-test2 ()
+  (let ((cpp-file (f-join test-data-dir-proj1 "src" "cpp" "test.cpp")))
+    (with-current-buffer (find-file-noselect cpp-file t)
+      (goto-char (point-min))
+      (forward-line 8)
+      (forward-char 9)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 1 6))
+       (should (string= cpp-file (dumb-jump-go)))))))
+
+(ert-deftest dumb-jump-cpp-issue87 ()
+  (let ((cpp-file (f-join test-data-dir-proj1 "src" "cpp" "issue-87.cpp")))
+    (with-current-buffer (find-file-noselect cpp-file t)
+      (goto-char (point-min))
+      (forward-line 16)
+      (forward-char 12)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 6 18))
+       (should (string= cpp-file (dumb-jump-go)))))))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -259,30 +259,34 @@
     (dumb-jump-output-rule-test-failures rule-failures)
     (should (= (length rule-failures) 0))))
 
-(ert-deftest dumb-jump-test-ag-rules-test ()
-  (let ((rule-failures (dumb-jump-test-ag-rules)))
-    (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+(when (dumb-jump-ag-installed?)
+  (ert-deftest dumb-jump-test-ag-rules-test ()
+    (let ((rule-failures (dumb-jump-test-ag-rules)))
+      (dumb-jump-output-rule-test-failures rule-failures)
+      (should (= (length rule-failures) 0)))))
 
-(ert-deftest dumb-jump-test-rg-rules-test ()
-  (let ((rule-failures (dumb-jump-test-rg-rules)))
-    (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+(when (dumb-jump-rg-installed?)
+  (ert-deftest dumb-jump-test-rg-rules-test ()
+    (let ((rule-failures (dumb-jump-test-rg-rules)))
+      (dumb-jump-output-rule-test-failures rule-failures)
+      (should (= (length rule-failures) 0)))))
 
 (ert-deftest dumb-jump-test-rules-not-test () ;; :not tests
   (let ((rule-failures (dumb-jump-test-rules t)))
     (dumb-jump-output-rule-test-failures rule-failures)
     (should (= (length rule-failures) 0))))
 
-(ert-deftest dumb-jump-test-ag-rules-not-test () ;; :not tests
-  (let ((rule-failures (dumb-jump-test-ag-rules t)))
+(when (dumb-jump-ag-installed?)
+  (ert-deftest dumb-jump-test-ag-rules-not-test () ;; :not tests
+    (let ((rule-failures (dumb-jump-test-ag-rules t)))
     (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+    (should (= (length rule-failures) 0)))))
 
-(ert-deftest dumb-jump-test-rg-rules-not-test () ;; :not tests
-  (let ((rule-failures (dumb-jump-test-rg-rules t)))
-    (dumb-jump-output-rule-test-failures rule-failures)
-    (should (= (length rule-failures) 0))))
+(when (dumb-jump-rg-installed?)
+  (ert-deftest dumb-jump-test-rg-rules-not-test () ;; :not tests
+    (let ((rule-failures (dumb-jump-test-rg-rules t)))
+      (dumb-jump-output-rule-test-failures rule-failures)
+      (should (= (length rule-failures) 0)))))
 
 (ert-deftest dumb-jump-test-rules-fail-test ()
   (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
@@ -291,19 +295,21 @@
     ;(message "%s" (prin1-to-string rule-failures))
     (should (= (length rule-failures) 1))))
 
-(ert-deftest dumb-jump-test-ag-rules-fail-test ()
-  (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
-         (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
-         (rule-failures (dumb-jump-test-ag-rules)))
-    ;(message "%s" (prin1-to-string rule-failures))
-    (should (= (length rule-failures) 1))))
+(when (dumb-jump-ag-installed?)
+  (ert-deftest dumb-jump-test-ag-rules-fail-test ()
+    (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
+	   (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
+	   (rule-failures (dumb-jump-test-ag-rules)))
+					;(message "%s" (prin1-to-string rule-failures))
+      (should (= (length rule-failures) 1)))))
 
-(ert-deftest dumb-jump-test-rg-rules-fail-test ()
-  (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
-         (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
-         (rule-failures (dumb-jump-test-rg-rules)))
-    ;(message "%s" (prin1-to-string rule-failures))
-    (should (= (length rule-failures) 1))))
+(when (dumb-jump-rg-installed?)
+  (ert-deftest dumb-jump-test-rg-rules-fail-test ()
+    (let* ((bad-rule '(:type "variable" :supports ("ag" "grep" "rg") :language "elisp" :regex "\\\(defvarJJJ\\b\\s*" :tests ("(defvar test ")))
+	   (dumb-jump-find-rules (cons bad-rule dumb-jump-find-rules))
+	   (rule-failures (dumb-jump-test-rg-rules)))
+					;(message "%s" (prin1-to-string rule-failures))
+      (should (= (length rule-failures) 1)))))
 
 (ert-deftest dumb-jump-match-test ()
   (should (not (dumb-jump-re-match nil "asdf")))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -14,6 +14,7 @@
 (setq test-data-dir (f-expand "./test/data"))
 (setq test-data-dir-elisp (f-join test-data-dir "proj2-elisp"))
 (setq test-data-dir-proj1 (f-join test-data-dir "proj1"))
+(setq test-data-dir-multiproj (f-join test-data-dir "multiproj"))
 
 (ert-deftest data-dir-exists-test ()
   (should (f-dir? test-data-dir)))
@@ -872,3 +873,18 @@
       (with-mock
        (mock (dumb-jump-goto-file-line * 6 18))
        (should (string= cpp-file (dumb-jump-go)))))))
+
+;; This test verifies that having ".dumbjumpignore" files in the two sub-projects will make it find
+;; the "multiproj" folder as project root since it has a ".dumbjump" file. The two sub-projects have
+;; a dummy ".git" folder to signify it as a repository that would normally become the root without
+;; the ignore file.
+(ert-deftest dumb-jump-multiproj ()
+  (let ((main-file (f-join test-data-dir-multiproj "subproj1" "main.cc"))
+        (header-file (f-join test-data-dir-multiproj "subproj2" "header.h")))
+    (with-current-buffer (find-file-noselect main-file t)
+      (goto-char (point-min))
+      (forward-line 3)
+      (forward-char 18)
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 6 6))
+       (should (string= header-file (dumb-jump-go)))))))


### PR DESCRIPTION
If a project has a ".dumbjumpignore" file it won't be detected as a project root even though it has
another project root denoter, like ".git" etc. This makes it possible to have a fallback top project
so searches can lookup things from other sub-projects.

Added a test case to verify it.

It fixes issue #36.