### PR TITLE
Only search file extensions with git-grep

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1571,10 +1571,10 @@ Ffrom the ROOT project CONFIG-FILE."
 (defun dumb-jump-generate-rg-command (look-for cur-file proj regexes lang exclude-paths)
   "Generate the rg response based on the needle LOOK-FOR in the directory PROJ."
   (let* ((filled-regexes (dumb-jump-populate-regexes look-for regexes 'rg))
-         (agtypes (dumb-jump-get-rg-type-by-language lang))
+         (rgtypes (dumb-jump-get-rg-type-by-language lang))
          (cmd (concat dumb-jump-rg-cmd
                       " --color never --no-heading --line-number"
-                      (s-join "" (--map (format " --type %s" it) agtypes))))
+                      (s-join "" (--map (format " --type %s" it) rgtypes))))
          (exclude-args (dumb-jump-arg-joiner
                         "-g" (--map (shell-quote-argument (concat "!" (s-replace proj "" it))) exclude-paths)))
          (regex-args (shell-quote-argument (s-join "|" filled-regexes))))
@@ -1585,15 +1585,17 @@ Ffrom the ROOT project CONFIG-FILE."
 (defun dumb-jump-generate-git-grep-command (look-for cur-file proj regexes lang exclude-paths)
   "Generate the git grep response based on the needle LOOK-FOR in the directory PROJ."
   (let* ((filled-regexes (dumb-jump-populate-regexes look-for regexes 'git-grep))
+         (ggtypes (dumb-jump-get-git-grep-type-by-language lang))
          (cmd (concat dumb-jump-git-grep-cmd
                       " --color=never --line-number -E"))
+         (fileexps (s-join " " (--map (shell-quote-argument (format "%s/*.%s" proj it)) ggtypes)))
          (exclude-args (s-join " "
                                (--map (shell-quote-argument (concat ":(exclude)" it))
                                       exclude-paths)))
          (regex-args (shell-quote-argument (s-join "|" filled-regexes))))
     (if (= (length regexes) 0)
         ""
-        (dumb-jump-concat-command cmd regex-args "--" proj exclude-args))))
+        (dumb-jump-concat-command cmd regex-args "--" fileexps exclude-args))))
 
 (defun dumb-jump-generate-grep-command (look-for cur-file proj regexes lang exclude-paths)
   "Find LOOK-FOR's CUR-FILE in the PROJ with REGEXES for the LANG but not in EXCLUDE-PATHS."
@@ -1649,6 +1651,14 @@ Ffrom the ROOT project CONFIG-FILE."
   (-distinct (--map (plist-get it :rgtype)
                     (--filter (and
                                (plist-get it :rgtype)
+                               (string= (plist-get it :language) language))
+                              dumb-jump-language-file-exts))))
+
+(defun dumb-jump-get-git-grep-type-by-language (language)
+  "Return list of git grep type argument for a LANGUAGE."
+  (-distinct (--map (plist-get it :ext)
+                    (--filter (and
+                               (plist-get it :ext)
                                (string= (plist-get it :language) language))
                               dumb-jump-language-file-exts))))
 

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -842,6 +842,9 @@
 (ert-deftest dumb-jump-rgtype-test ()
   (should (equal (dumb-jump-get-rg-type-by-language "python") '("py"))))
 
+(ert-deftest dumb-jump-git-grep-type-test ()
+  (should (equal (dumb-jump-get-git-grep-type-by-language "python") '("py"))))
+
 ;; react tests
 
 (ert-deftest dumb-jump-react-test1 ()

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -117,8 +117,9 @@
 (ert-deftest dumb-jump-generate-git-grep-command-no-ctx-test ()
   (let* ((regexes (dumb-jump-get-contextual-regexes "elisp" nil))
          (expected-regexes "\\((defun|cl-defun)\\s+tester($|[^\\w-])|\\(defvar\\b\\s*tester($|[^\\w-])|\\(defcustom\\b\\s*tester($|[^\\w-])|\\(setq\\b\\s*tester($|[^\\w-])|\\(tester\\s+|\\((defun|cl-defun)\\s*.+\\(?\\s*tester($|[^\\w-])\\s*\\)?")
-         (expected (concat "git grep --color=never --line-number -E " (shell-quote-argument expected-regexes) " -- .")))
-    (should (string= expected  (dumb-jump-generate-git-grep-command  "tester" "blah.el" "." regexes "elisp" nil)))))
+         (excludes '("one" "two" "three"))
+         (expected (concat "git grep --color=never --line-number -E " (shell-quote-argument expected-regexes) " -- ./\\*.el ./\\*.el.gz \\:\\(exclude\\)one \\:\\(exclude\\)two \\:\\(exclude\\)three")))
+    (should (string= expected  (dumb-jump-generate-git-grep-command  "tester" "blah.el" "." regexes "elisp" excludes)))))
 
 (ert-deftest dumb-jump-generate-grep-command-no-ctx-funcs-only-test ()
   (let* ((system-type 'darwin)


### PR DESCRIPTION
`ag` and `rg` only searches the file extensions by the given language and now so does `git grep`. It's a lot faster, too! Even when compared to `ag`.

I have pretty big work repo and I tired using `ag` and `git grep` on the same symbol:

- `ag` took 1.381814956665039 seconds
- `git grep` w/o using extensions took 10.966195106506348 seconds
- **`git grep` w.  extensions took 0.087921142578125 seconds**