### PR TITLE
Helm preview choices on C-j

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -996,8 +996,9 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
           (dumb-jump-result-follow result))))
 
 (defun dumb-jump-helm-persist-action (match)
-  (let* ((values (s-split " " match))
-         (file-line-part (s-split ":" (nth 0 values)))
+  (let* ((parts (--remove (string= it "")
+                          (s-split "\\(?:^\\|:\\)[0-9]+:"  match)))
+         (file-line-part (s-split ":" (nth 0 parts)))
          (file (nth 0 file-line-part))
          (line (string-to-number (nth 1 file-line-part)))
          (default-directory-old default-directory))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -995,8 +995,25 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
         (when result
           (dumb-jump-result-follow result))))
 
+(defun dumb-jump-helm-persist-action (match)
+  (let* ((values (s-split " " match))
+         (file-line-part (s-split ":" (nth 0 values)))
+         (file (nth 0 file-line-part))
+         (line (string-to-number (nth 1 file-line-part)))
+         (default-directory-old default-directory))
+    (switch-to-buffer (get-buffer-create " *helm dump jump persistent*"))
+    (setq default-directory default-directory-old)
+    (fundamental-mode)
+    (erase-buffer)
+    (insert-file-contents file)
+    (let ((buffer-file-name file))
+      (set-auto-mode)
+      (font-lock-fontify-region (point-min) (point-max))
+      (goto-line line))))
+
 (defun dumb-jump-prompt-user-for-choice (proj results)
-  "Put a PROJ's list of RESULTS in a 'popup-menu' (or helm/ivy) for user to select.  Filters PROJ path from files for display."
+  "Put a PROJ's list of RESULTS in a 'popup-menu' (or helm/ivy)
+for user to select.  Filters PROJ path from files for display."
   (let* ((choices (-map (lambda (result)
                           (format "%s:%s %s"
                                   (s-replace proj "" (plist-get result :path))
@@ -1007,7 +1024,12 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
      ((and (eq dumb-jump-selector 'ivy) (fboundp 'ivy-read))
       (dumb-jump-to-selected results choices (ivy-read "Jump to: " choices)))
      ((and (eq dumb-jump-selector 'helm) (fboundp 'helm))
-      (dumb-jump-to-selected results choices (helm :sources (helm-build-sync-source "Jump to: " :candidates choices))))
+      (dumb-jump-to-selected results choices
+                             (helm :sources
+                                   (helm-build-sync-source "Jump to: "
+                                     :candidates choices
+                                     :persistent-action 'dumb-jump-helm-persist-action)
+                                   :buffer "*helm dumb jump choices*")))
      (t
       (dumb-jump-to-selected results choices (popup-menu* choices))))))
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -996,6 +996,8 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
           (dumb-jump-result-follow result))))
 
 (defun dumb-jump-helm-persist-action (match)
+  "Previews a MATCH in a temporary buffer at the matched line
+number when pressing C-j in helm."
   (let* ((parts (--remove (string= it "")
                           (s-split "\\(?:^\\|:\\)[0-9]+:"  match)))
          (file-line-part (s-split ":" (nth 0 parts)))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1004,7 +1004,7 @@ number when pressing C-j in helm."
          (file (nth 0 file-line-part))
          (line (string-to-number (nth 1 file-line-part)))
          (default-directory-old default-directory))
-    (switch-to-buffer (get-buffer-create " *helm dump jump persistent*"))
+    (switch-to-buffer (get-buffer-create " *helm dumb jump persistent*"))
     (setq default-directory default-directory-old)
     (fundamental-mode)
     (erase-buffer)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -394,6 +394,10 @@
      (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
+(ert-deftest dumb-jump-prompt-user-for-choice-correct-helm-persistent-action-test ()
+  (dumb-jump-helm-persist-action "dumb-jump.el:1")
+  (should (get-buffer " *helm dumb jump persistent*")))
+
 (ert-deftest dumb-jump-prompt-user-for-choice-correct-ivy-test ()
   (let* ((dumb-jump-selector 'ivy)
          (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -389,8 +389,8 @@
          (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")
                     (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
     (with-mock
-     (mock (helm-build-sync-source * :candidates *))
-     (mock (helm * *) => "/test2.txt:52 var thing = function()")
+     (mock (helm-build-sync-source * :candidates * :persistent-action *))
+     (mock (helm * * :buffer "*helm dumb jump choices*") => "/test2.txt:52 var thing = function()")
      (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 


### PR DESCRIPTION
When using helm it is usually the case that <kbd>C-j</kbd> executes a persistent action, meaning to preview something while keeping the helm candidates buffer open.

I've implemented so <kbd>C-j</kbd> will preview the match at current line of the helm candidates lines in another temporary buffer until (1) hitting <kbd>enter</kbd> and it jumps to the file at that line, or (2) <kbd>C-g</kbd> will abort helm and return to the original buffer position.