### PR TITLE
Improve PHP variable and class detection

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -449,8 +449,8 @@ using searcher git-grep."
            :tests ("function test()" "function test ()"))
 
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "php"
-           :regex "JJJ\\s*=\\s*"
-           :tests ("$test = 1234"))
+           :regex "(\\s|->|\\$|::)JJJ\\s*=\\s*"
+           :tests ("$test = 1234" "$foo->test = 1234"))
 
     (:type "trait" :supports ("ag" "grep" "rg" "git-grep") :language "php"
            :regex "trait\\s*JJJ\\s*\\\{"
@@ -461,8 +461,8 @@ using searcher git-grep."
            :tests ("interface test{" "interface test {"))
 
     (:type "class" :supports ("ag" "grep" "rg" "git-grep") :language "php"
-           :regex "class\\s*JJJ\\s*\\\{"
-           :tests ("class test{" "class test {"))
+           :regex "class\\s*JJJ\\s*(extends|implements|\\\{)"
+           :tests ("class test{" "class test {" "class test extends foo" "class test implements foo"))
 
     ;; faust
     (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "faust"


### PR DESCRIPTION
I don't have a test for the "space with keyword" because you only use "test" as keyword. But when jumping to definition, emacs also includes a leading dollar sign into the word, thus searches for `$foo` - so the test would need to look for `$test` to make sense.

Same for `::$foo`