### PR TITLE
Sort matches better and correctly filter current file

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1350,28 +1350,42 @@ PREFER-EXTERNAL will sort current file last."
          (match-sorted (-sort (lambda (x y) (< (plist-get x :diff) (plist-get y :diff))) results))
          (match-no-comments (dumb-jump-filter-no-start-comments match-sorted lang))
 
+         ;; Find the relative current file path by the project root. In some cases the results will
+         ;; not be absolute but relative and the "current file" filters must match in both cases.
+         (rel-cur-file
+          (if (s-starts-with? proj-root cur-file)
+              (substring cur-file (1+ (length proj-root)) (length cur-file))
+            cur-file))
+
          ;; Moves current file results to the front of the list, unless PREFER-EXTERNAL then put
          ;; them last.
          (match-cur-file-front
           (if (not prefer-external)
               (-concat
                (--filter (and (> (plist-get it :diff) 0)
-                              (string= (plist-get it :path) cur-file))
+                              (or (string= (plist-get it :path) cur-file)
+                                  (string= (plist-get it :path) rel-cur-file)))
                          match-no-comments)
                (--filter (and (<= (plist-get it :diff) 0)
-                              (string= (plist-get it :path) cur-file))
+                              (or (string= (plist-get it :path) cur-file)
+                                  (string= (plist-get it :path) rel-cur-file)))
                          match-no-comments)
-               (--filter (not (string= (plist-get it :path) cur-file))
+               (--filter (not (or (string= (plist-get it :path) cur-file)
+                                  (string= (plist-get it :path) rel-cur-file)))
                          match-no-comments))
             (-concat
-             (--filter (not (string= (plist-get it :path) cur-file))
+             (--filter (not (or (string= (plist-get it :path) cur-file)
+                                (string= (plist-get it :path) rel-cur-file)))
                        match-no-comments)
-             (--filter (string= (plist-get it :path) cur-file)
+             (--filter (or (string= (plist-get it :path) cur-file)
+                           (string= (plist-get it :path) rel-cur-file))
                        match-no-comments))))
 
          (matches
           (if (not prefer-external)
-              (dumb-jump-current-file-results cur-file match-cur-file-front)
+              (-distinct
+               (append (dumb-jump-current-file-results cur-file match-cur-file-front)
+                       (dumb-jump-current-file-results rel-cur-file match-cur-file-front)))
             match-cur-file-front))
 
          (var-to-jump (car matches))
@@ -1381,8 +1395,8 @@ PREFER-EXTERNAL will sort current file last."
                                (string= ctx-type ""))
                            var-to-jump)))
      ;; (dumb-jump-message-prin1
-     ;;  "type: %s | jump? %s | matches: %s | sorted-no-comments: %s | results: %s | prefer external: %s"
-     ;;  ctx-type var-to-jump matches match-no-comments results prefer-external)
+     ;;  "type: %s | jump? %s | matches: %s  | results: %s | prefer external: %s\n\nmatch-cur-file-front: %s\nproj-root: %s\ncur-file: %s\nreal-cur-file: %s"
+     ;;  ctx-type var-to-jump match-cur-file-front results prefer-external match-cur-file-front proj-root cur-file rel-cur-file)
     (if do-var-jump
         (dumb-jump-result-follow var-to-jump use-tooltip proj-root)
       (dumb-jump-prompt-user-for-choice proj-root match-cur-file-front))))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1370,13 +1370,22 @@ PREFER-EXTERNAL will sort current file last."
                               (or (string= (plist-get it :path) cur-file)
                                   (string= (plist-get it :path) rel-cur-file)))
                          match-no-comments)
-               (--filter (not (or (string= (plist-get it :path) cur-file)
-                                  (string= (plist-get it :path) rel-cur-file)))
-                         match-no-comments))
+
+               ;; Sort non-current files by path length so the nearest file is more likely to be
+               ;; sorted higher to the top. Also sorts by line number for sanity.
+               (-sort (lambda (x y)
+                        (and (< (plist-get x :line) (plist-get y :line))
+                             (< (length (plist-get x :path)) (length (plist-get y :path)))))
+                      (--filter (not (or (string= (plist-get it :path) cur-file)
+                                         (string= (plist-get it :path) rel-cur-file)))
+                                match-no-comments)))
             (-concat
-             (--filter (not (or (string= (plist-get it :path) cur-file)
-                                (string= (plist-get it :path) rel-cur-file)))
-                       match-no-comments)
+             (-sort (lambda (x y)
+                      (and (< (plist-get x :line) (plist-get y :line))
+                           (< (length (plist-get x :path)) (length (plist-get y :path)))))
+                    (--filter (not (or (string= (plist-get it :path) cur-file)
+                                       (string= (plist-get it :path) rel-cur-file)))
+                              match-no-comments))
              (--filter (or (string= (plist-get it :path) cur-file)
                            (string= (plist-get it :path) rel-cur-file))
                        match-no-comments))))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1351,11 +1351,19 @@ PREFER-EXTERNAL will sort current file last."
          (match-no-comments (dumb-jump-filter-no-start-comments match-sorted lang))
 
          ;; Find the relative current file path by the project root. In some cases the results will
-         ;; not be absolute but relative and the "current file" filters must match in both cases.
+         ;; not be absolute but relative and the "current file" filters must match in both
+         ;; cases. Also works when current file is in an arbitrary sub folder.
          (rel-cur-file
-          (if (s-starts-with? proj-root cur-file)
-              (substring cur-file (1+ (length proj-root)) (length cur-file))
-            cur-file))
+          (cond ((and (s-starts-with? proj-root cur-file)
+                      (s-starts-with? default-directory cur-file))
+                 (substring cur-file (length default-directory) (length cur-file)))
+
+                ((and (s-starts-with? proj-root cur-file)
+                      (not (s-starts-with? default-directory cur-file)))
+                 (substring cur-file (1+ (length proj-root)) (length cur-file)))
+
+                (t
+                 cur-file)))
 
          ;; Moves current file results to the front of the list, unless PREFER-EXTERNAL then put
          ;; them last.

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1113,3 +1113,12 @@
          (gen-funcs (dumb-jump-generators-by-searcher 'grep))
          (variant (dumb-jump-pick-grep-variant)))
     (should (generator-plist-equal gen-funcs variant))))
+
+;; This test makes sure that if the `cur-file' is absolute but results are relative, then it must
+;; still find and sort results correctly.
+(ert-deftest dumb-jump-handle-results-relative-current-file-test ()
+  (let ((results '((:path "relfile.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow")
+                   (:path "src/absfile.js" :line 69 :context "isNow = false" :diff 0 :target "isNow"))))
+    (with-mock
+     (mock (dumb-jump-goto-file-line "relfile.js" 62 4))
+     (dumb-jump-handle-results results "/code/redux/relfile.js" "/code/redux" "" "isNow" nil nil))))


### PR DESCRIPTION
Two things:

1. The current file wasn't correctly being determined in all cases. Let's say the project root is "/some/path" and the `cur-file` is "/some/path/Controller.cc". However, some results are relative to the file the searcher was initiated from, so in this case, it would be "Controller.cc" and not being matched. Another case is for results of files in any arbitrary subfolder. For instance, if `cur-file` is "/some/path/src/db/Controller.cc" the relative path is "src/db/Controller.cc", which is neither of `cur-file` or "Controller.cc" - but it is handled by using `default-directory`.

2. For sanity and convenience, I'm now sorting non-current files by shortest path/lowest line number first. This means that the chance of having a result sorted high to the top is higher for matches in files close to the current file, i.e. folder names and "../../.." etc. makes the path longer. So instead of seeing:

- Controller.cc:101    static void loadQtResources()
- ../monitor/ui/ConfigEditor.cc:27    static void loadQtResources()
- OtherStuff.cc:99    static void loadQtResources()
- ../updatemonitor/UpdateMonitor.cc:20    static void loadQtResources()

It would show:
- Controller.cc:101    static void loadQtResources()
- OtherStuff.cc:99    static void loadQtResources()
- ../monitor/ui/ConfigEditor.cc:27    static void loadQtResources()
- ../updatemonitor/UpdateMonitor.cc:20    static void loadQtResources()

With "Controller.cc" being the current file so it is sorted first, of course.

I hope this makes sense.