### PR TITLE
Introduced aggressive mode

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -827,6 +827,13 @@ a symbol then it's probably a function call"
   :group 'dumb-jump
   :type 'hook)
 
+(defcustom dumb-jump-aggressive
+  t
+  "If `t' jump aggressively with the possiblity of a false
+positive. If `nil' always show list of more than 1 match."
+  :group 'dumb-jump
+  :type 'boolean)
+
 (defun dumb-jump-message-prin1 (str &rest args)
   "Helper function when debugging apply STR 'prin1-to-string' to all ARGS."
   (apply 'message str (-map 'prin1-to-string args)))
@@ -1406,10 +1413,16 @@ PREFER-EXTERNAL will sort current file last."
 
          (var-to-jump (car matches))
          ;; TODO: handle if ctx-type is null but ALL results are variable
-         (do-var-jump (and (or (= (length matches) 1)
-                               (string= ctx-type "variable")
-                               (string= ctx-type ""))
-                           var-to-jump)))
+
+         ;; When non-aggressive it should only jump when there is only one match, regardless of
+         ;; context.
+         (do-var-jump
+          (and (or dumb-jump-aggressive
+                   (= (length match-cur-file-front) 1))
+               (or (= (length matches) 1)
+                   (string= ctx-type "variable")
+                   (string= ctx-type ""))
+               var-to-jump)))
      ;; (dumb-jump-message-prin1
      ;;  "type: %s | jump? %s | matches: %s  | results: %s | prefer external: %s\n\nmatch-cur-file-front: %s\nproj-root: %s\ncur-file: %s\nreal-cur-file: %s"
      ;;  ctx-type var-to-jump match-cur-file-front results prefer-external match-cur-file-front proj-root cur-file rel-cur-file)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1122,3 +1122,29 @@
     (with-mock
      (mock (dumb-jump-goto-file-line "relfile.js" 62 4))
      (dumb-jump-handle-results results "/code/redux/relfile.js" "/code/redux" "" "isNow" nil nil))))
+
+;; Make sure it jumps aggressively, i.e. normally.
+(ert-deftest dumb-jump-handle-results-aggressively-test ()
+  (let ((dumb-jump-aggressive t)
+        (results '((:path "relfile.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow")
+                   (:path "src/absfile.js" :line 69 :context "isNow = false" :diff 0 :target "isNow"))))
+    (with-mock
+     (mock (dumb-jump-goto-file-line "relfile.js" 62 4))
+     (dumb-jump-handle-results results "relfile.js" "/code/redux" "" "isNow" nil nil))))
+
+;; Make sure non-aggressive mode shows choices when more than one possibility.
+(ert-deftest dumb-jump-handle-results-non-aggressively-test ()
+  (let ((dumb-jump-aggressive nil)
+        (results '((:path "relfile.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow")
+                   (:path "src/absfile.js" :line 69 :context "isNow = false" :diff 0 :target "isNow"))))
+    (with-mock
+     (mock (dumb-jump-prompt-user-for-choice "/code/redux" *))
+     (dumb-jump-handle-results results "relfile.js" "/code/redux" "" "isNow" nil nil))))
+
+;; Make sure it jumps when there's only one possiblity in non-aggressive mode.
+(ert-deftest dumb-jump-handle-results-non-aggressive-do-jump-test ()
+  (let ((dumb-jump-aggressive nil)
+        (results '((:path "relfile.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow"))))
+    (with-mock
+     (mock (dumb-jump-goto-file-line "relfile.js" 62 4))
+     (dumb-jump-handle-results results "relfile.js" "/code/redux" "" "isNow" nil nil))))


### PR DESCRIPTION
This PR fixes #122 which has more information about the thought processes.

Essentially, there's now a new variable `dumb-jump-aggressive` that defaults to `t` and makes Dumb Jump work like it normally does. If it is set to `nil` then it will only do a variable jump if there's a single match; in the current file and any other files.