### PR TITLE
Shell support

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1570,10 +1570,10 @@ searcher symbol."
       "-icf")
 
      ((string-equal "bash" base-name)
-      "--noprofile --norc -c")
+      "-c")
 
      (t
-      "-c"))))
+      shell-command-switch))))
 
 ;; TODO: rename dumb-jump-run-definition-command
 (defun dumb-jump-run-command

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1558,11 +1558,29 @@ searcher symbol."
    (t
     (dumb-jump-generators-by-searcher 'grep))))
 
+(defun dumb-jump-shell-command-switch ()
+  "Yields the shell command switch to use for the current
+  `shell-file-name' in order to not load the shell profile/RC for
+  speeding up things."
+  (let ((base-name (downcase (file-name-base shell-file-name))))
+    (cond
+     ((or (string-equal "zsh" base-name)
+          (string-equal "csh" base-name)
+          (string-equal "tcsh" base-name))
+      "-icf")
+
+     ((string-equal "bash" base-name)
+      "--noprofile --norc -c")
+
+     (t
+      "-c"))))
+
 ;; TODO: rename dumb-jump-run-definition-command
 (defun dumb-jump-run-command
     (look-for proj regexes lang exclude-args cur-file line-num parse-fn generate-fn)
   "Run the grep command based on the needle LOOK-FOR in the directory TOSEARCH"
   (let* ((cmd (funcall generate-fn look-for cur-file proj regexes lang exclude-args))
+         (shell-command-switch (dumb-jump-shell-command-switch))
          (rawresults (shell-command-to-string cmd)))
 
     ;;(dumb-jump-message-prin1 "NORMAL RUN: CMD '%s' RESULTS: %s" cmd rawresults)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1164,3 +1164,7 @@
 (ert-deftest dumb-jump-shell-command-switch-bash-test ()
   (let ((shell-file-name "/usr/bin/bash"))
     (should (string-equal "-c" (dumb-jump-shell-command-switch)))))
+
+(ert-deftest dumb-jump-shell-command-switch-unknown-test ()
+  (let ((shell-file-name "/usr/bin/thisshelldoesnotexist"))
+    (should (string-equal shell-command-switch (dumb-jump-shell-command-switch)))))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1148,3 +1148,19 @@
     (with-mock
      (mock (dumb-jump-goto-file-line "relfile.js" 62 4))
      (dumb-jump-handle-results results "relfile.js" "/code/redux" "" "isNow" nil nil))))
+
+(ert-deftest dumb-jump-shell-command-switch-zsh-test ()
+  (let ((shell-file-name "/usr/bin/zsh"))
+    (should (string-equal "-icf" (dumb-jump-shell-command-switch)))))
+
+(ert-deftest dumb-jump-shell-command-switch-csh-test ()
+  (let ((shell-file-name "/usr/bin/csh"))
+    (should (string-equal "-icf" (dumb-jump-shell-command-switch)))))
+
+(ert-deftest dumb-jump-shell-command-switch-tcsh-test ()
+  (let ((shell-file-name "/usr/bin/zsh"))
+    (should (string-equal "-icf" (dumb-jump-shell-command-switch)))))
+
+(ert-deftest dumb-jump-shell-command-switch-bash-test ()
+  (let ((shell-file-name "/usr/bin/bash"))
+    (should (string-equal "--noprofile --norc -c" (dumb-jump-shell-command-switch)))))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1163,4 +1163,4 @@
 
 (ert-deftest dumb-jump-shell-command-switch-bash-test ()
   (let ((shell-file-name "/usr/bin/bash"))
-    (should (string-equal "--noprofile --norc -c" (dumb-jump-shell-command-switch)))))
+    (should (string-equal "-c" (dumb-jump-shell-command-switch)))))


### PR DESCRIPTION
Fixes #124.

No profile or RC files are loaded when executing a search to speed things up and avoid unnecessary things being run, which can potentially yield erroneous path names.