### PR TITLE
Allow jumping from/to modified files

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1486,7 +1486,13 @@ Ffrom the ROOT project CONFIG-FILE."
 
 (defun dumb-jump-file-modified-p (path)
   "Check if PATH is currently open in Emacs and has a modified buffer."
-  (member path (--map (buffer-file-name it) (--filter (and (buffer-modified-p it) (file-exists-p (or (buffer-file-name) "ZZ"))) (buffer-list)))))
+  (let ((modified-file-buffers
+         (--filter
+          (and (buffer-modified-p it)
+               (buffer-file-name it)
+               (file-exists-p (buffer-file-name it)))
+          (buffer-list))))
+    (member path (--map (buffer-file-name it) modified-file-buffers))))
 
 (defun dumb-jump-result-follow (result &optional use-tooltip proj)
   "Take the RESULT to jump to and record the jump, for jumping back, and then trigger jump.  Prompt if we should continue if destentation has been modified."

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -844,8 +844,8 @@ a symbol then it's probably a function call"
 
 (defcustom dumb-jump-aggressive
   t
-  "If `t' jump aggressively with the possiblity of a false
-positive. If `nil' always show list of more than 1 match."
+  "If `t` jump aggressively with the possiblity of a false positive.
+If `nil` always show list of more than 1 match."
   :group 'dumb-jump
   :type 'boolean)
 
@@ -1130,8 +1130,6 @@ to keep looking for another root."
    ((or (string= (buffer-name) "*shell*")
         (string= (buffer-name) "*eshell*"))
     (dumb-jump-fetch-shell-results prompt))
-   ((buffer-modified-p (current-buffer))
-    (dumb-jump-issue-result "unsaved"))
    ((and (not prompt) (not (region-active-p)) (not (thing-at-point 'symbol)))
     (dumb-jump-issue-result "nosymbol"))
    (t
@@ -1303,8 +1301,6 @@ current file."
       (dumb-jump-message
        "Took over %ss to find '%s'. Please install ag or rg, or add a .dumbjump file to '%s' with path exclusions"
        (number-to-string dumb-jump-max-find-time) look-for proj-root))
-     ((eq issue 'unsaved)
-      (dumb-jump-message "Please save your file before jumping."))
      ((eq issue 'nogrep)
       (dumb-jump-message "Please install ag, rg, git grep or grep!"))
      ((eq issue 'nosymbol)
@@ -1488,7 +1484,18 @@ Ffrom the ROOT project CONFIG-FILE."
 
     `(:exclude ,exclude-paths :include ,include-paths :language ,lang)))
 
+(defun dumb-jump-file-modified-p (path)
+  "Check if PATH is currently open in Emacs and has a modified buffer."
+  (member path (--map (buffer-file-name it) (--filter (and (buffer-modified-p it) (file-exists-p (or (buffer-file-name) "ZZ"))) (buffer-list)))))
+
 (defun dumb-jump-result-follow (result &optional use-tooltip proj)
+  "Take the RESULT to jump to and record the jump, for jumping back, and then trigger jump.  Prompt if we should continue if destentation has been modified."
+  (if (dumb-jump-file-modified-p (plist-get result :path))
+      (when (y-or-n-p (concat (plist-get result :path) " has been modified so we may have the wrong location. Continue?"))
+        (dumb-jump--result-follow result use-tooltip proj))
+    (dumb-jump--result-follow result use-tooltip proj)))
+
+(defun dumb-jump--result-follow (result &optional use-tooltip proj)
   "Take the RESULT to jump to and record the jump, for jumping back, and then trigger jump."
   (let* ((target-boundary (s-matched-positions-all
                            (concat "\\b" (regexp-quote (plist-get result :target)) "\\b")

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -709,16 +709,6 @@
      ;; confirm memoization of the previous result
      (should (eq (dumb-jump-git-grep-installed?) t)))))
 
-(ert-deftest dumb-jump-go-unsaved-test ()
-  (let ((js-file (f-join test-data-dir-proj1 "src" "js" "fake2.js")))
-    (with-current-buffer (find-file-noselect js-file t)
-      (goto-char (point-min))
-      (forward-char 13)
-      (with-mock
-       (mock (buffer-modified-p *) => t)
-       (mock (dumb-jump-message "Please save your file before jumping."))
-       (dumb-jump-go)))))
-
 (ert-deftest dumb-jump-go-nogrep-test ()
   (let ((js-file (f-join test-data-dir-proj1 "src" "js" "fake2.js")))
     (with-current-buffer (find-file-noselect js-file t)
@@ -741,12 +731,6 @@
        (mock (dumb-jump-message "No symbol under point."))
        (dumb-jump-go)))))
 
-(ert-deftest dumb-jump-message-get-results-unsaved-test ()
-  (with-mock
-   (mock (buffer-modified-p *) => t)
-   (let ((results (dumb-jump-get-results)))
-     (should (eq (plist-get results :issue) 'unsaved)))))
-
 (ert-deftest dumb-jump-message-get-results-nogrep-test ()
   (with-mock
    (mock (dumb-jump-rg-installed?) => nil)
@@ -760,13 +744,13 @@
   (with-mock
    (mock (dumb-jump-goto-file-line "src/file.js" 62 4))
    (let ((result '(:path "src/file.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow")))
-     (dumb-jump-result-follow result))))
+     (dumb-jump--result-follow result))))
 
 (ert-deftest dumb-jump-message-result-follow-tooltip-test ()
   (with-mock
    (mock (popup-tip "/file.js:62 var isNow = true"))
    (let ((result '(:path "src/file.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow")))
-     (dumb-jump-result-follow result t "src"))))
+     (dumb-jump--result-follow result t "src"))))
 
 (ert-deftest dumb-jump-populate-regexes-grep-test ()
   (should (equal (dumb-jump-populate-regexes "testvar" '("JJJ\\s*=\\s*") 'grep) '("testvar\\s*=\\s*")))
@@ -811,11 +795,11 @@
     (should (string= result2 "myfunc"))
     (should (string= result3 "myrubyfunc"))))
 
-(ert-deftest dumb-jump-result-follow-test ()
+(ert-deftest dumb-jump--result-follow-test ()
   (let* ((data '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
     (with-mock
      (mock (dumb-jump-goto-file-line "/usr/blah/test2.txt" 52 1))
-     (dumb-jump-result-follow data nil "/usr/blah"))))
+     (dumb-jump--result-follow data nil "/usr/blah"))))
 
 (ert-deftest dumb-jump-find-start-pos-test ()
   (let ((cur-pos 9)


### PR DESCRIPTION
This stops the whole `Please save your file before jumping` block, which was getting annoying for me because a good portion of the time I want to jump _from_ a file is when it's modified. 

This PR makes it so it's fine if the file you're jumping _from_ is modified, but it will warn/confirm you want to jump if the file you're jumping _to_ is modified. 

`(y-or-n-p (concat (plist-get result :path) " has been modified so we may have the wrong location. Continue?")`

This is because there's a high chance the jump location could be wrong since the search will obviously use what's already on disk (which was the original reason this was implemented in case you were jumping within the current file)