### PR TITLE
add css to javascript language

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -804,6 +804,7 @@ using searcher git-grep."
     (:language "javascript" :ext "jsx" :agtype "js" :rgtype "js")
     (:language "javascript" :ext "vue" :agtype "js" :rgtype "js")
     (:language "javascript" :ext "html" :agtype "html" :rgtype "html")
+    (:language "javascript" :ext "css" :agtype "css" :rgtype "css")
     (:language "lisp" :ext "lisp" :agtype "lisp" :rgtype "lisp")
     (:language "lisp" :ext "lsp" :agtype "lisp" :rgtype "lisp")
     (:language "lua" :ext "lua" :agtype "lua" :rgtype "lua")

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -73,7 +73,7 @@
 
 (ert-deftest dumb-jump-generate-cmd-include-args ()
   (let ((args (dumb-jump-get-ext-includes "javascript"))
-        (expected " --include \\*.js --include \\*.jsx --include \\*.vue --include \\*.html "))
+        (expected " --include \\*.js --include \\*.jsx --include \\*.vue --include \\*.html --include \\*.css "))
     (should (string= expected args))))
 
 (ert-deftest dumb-jump-generate-grep-command-no-ctx-test ()


### PR DESCRIPTION
it's common to reference css class name in javascript/html/jsx. For example, if jQuery, we use css class name as dom selector. In JSX , the css name could be used as a javascript object (using css-modules)