### PR TITLE
#150 enable lexical bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you want to stop a directory from registering as the project root (and have D
 
 * `(setq dumb-jump-default-project "~/code")` to change default project if one is not found (defaults to `~`)
 * `(setq dumb-jump-quiet t)` if Dumb Jump is too chatty.
-* To support more languages and/or definition types use `add-to-list` on `dumb-jump-find-rules` (see source code).
+* To support more languages and/or definition types customize `dumb-jump-find-rules` variable.
 * `(add-hook 'dumb-jump-after-jump-hook 'some-function)` to execute code after you jump
 * `(setq dumb-jump-selector 'ivy)` to use [ivy](https://github.com/abo-abo/swiper#ivy) instead of the default popup for multiple options.
 * `(setq dumb-jump-selector 'helm)` to use [helm](https://github.com/emacs-helm/helm) instead of the default popup for multiple options.


### PR DESCRIPTION
It's been observed that tests fail on GNU Emacs 24.3 if lexical-bindings are
enabled. There could be various reasons for this, but most obvious is
that Emacs 24.3 had `byte-compile-add-to-list` function, which was used
as byte-compiled version of `add-to-list`:
https://github.com/emacs-mirror/emacs/commit/0b31660d3c10a0f8e243dd67bd0ecaf2c847d1e6#diff-38337c5e732c14fa599af4a0f6e53f18L4272

ert-runner compiles files before the test run, so tests used the
compiled version.

This Pull Request rewrites functions that depended on add-to-list, and hopefully fixes #150.