### PR TITLE
Fix `dumb-jump-get-language-from-mode` for `cperl-mode` [#156]

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1229,7 +1229,7 @@ to keep looking for another root."
 
 (defun dumb-jump-get-language-from-mode ()
   "Extract the language from the 'major-mode' name.  Currently just everything before '-mode'."
-  (let ((lookup '(sh "shell"))
+  (let ((lookup '(sh "shell" cperl "perl"))
         (m (s-replace "-mode" "" (symbol-name major-mode))))
         (or (plist-get lookup (intern m)) m)))
 


### PR DESCRIPTION
The most commonly used mode for editing Perl files is `cperl-mode`. Prior to this patch, opening a Perl file without an extension would give an error message; this maps `cperl-mode` to `perl` as expected and then `dumb-jump` works.