### PR TITLE
add Erlang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ There is currently basic support for the following languages:
 * Coq
 * Elixir
 * Emacs Lisp
+* Erlang
 * Faust
 * Fortran
 * Go

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -829,7 +829,26 @@ or most optimal searcher."
     (:type "module" :supports ("ag" "grep" "rg" "git-grep") :language "elixir"
            :regex "defprotocol\\s+(\\w+\\.)*JJJ\\s+"
            :tests ("defprotocol test do"
-                   "defprotocol Foo.Bar.test do")))
+                   "defprotocol Foo.Bar.test do"))
+
+    ;; erlang
+    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "erlang"
+           :regex "^JJJ\\b\\s*\\\("
+           :tests ("test() ->"
+                   "test()->"
+                   "test(Foo) ->"
+                   "test (Foo,Bar) ->"
+                   "test(Foo, Bar)->"))
+
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "erlang"
+           :regex "\\s*JJJ\\s*=[^:=\\n]+"
+           :tests ("test = 1234")
+           :not ("if test =:= 1234"
+                 "if test == 1234"))
+
+    (:type "module" :supports ("ag" "grep" "rg" "git-grep") :language "erlang"
+           :regex "^\\-module\\\(JJJ\\\)"
+           :tests ("-module(test).")))
 
   "List of regex patttern templates organized by language and type to use for generating the grep command."
   :group 'dumb-jump
@@ -933,7 +952,8 @@ or most optimal searcher."
     (:language "swift" :ext "swift" :agtype nil :rgtype "swift")
     (:language "elixir" :ext "ex" :agtype "elixir" :rgtype "elixir")
     (:language "elixir" :ext "exs" :agtype "elixir" :rgtype "elixir")
-    (:language "elixir" :ext "eex" :agtype "elixir" :rgtype "elixir"))
+    (:language "elixir" :ext "eex" :agtype "elixir" :rgtype "elixir")
+    (:language "erlang" :ext "erl" :agtype "erlang" :rgtype "erlang"))
 
   "Mapping of programming language(s) to file extensions."
   :group 'dumb-jump
@@ -1498,7 +1518,8 @@ current file."
     (:comment ";" :language "scheme")
     (:comment "#" :language "shell")
     (:comment "//" :language "swift")
-    (:comment "#" :language "elixir"))
+    (:comment "#" :language "elixir")
+    (:comment "%" :language "erlang"))
   "List of one-line comments organized by language."
   :group 'dumb-jump
   :type

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -847,7 +847,7 @@ or most optimal searcher."
                  "if test == 1234"))
 
     (:type "module" :supports ("ag" "grep" "rg" "git-grep") :language "erlang"
-           :regex "^\\-module\\\(JJJ\\\)"
+           :regex "^-module\\\(JJJ\\\)"
            :tests ("-module(test).")))
 
   "List of regex patttern templates organized by language and type to use for generating the grep command."


### PR DESCRIPTION
Variable matching misses a lot of ways it is typical to bind variable in Erlang, but I don't think they could be covered without just finding everything that contains the term that is being searched for :(.