### PR TITLE
Modify format of choices; Move ivy selection function to user option

### DIFF
--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -388,7 +388,7 @@
   (let* ((results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")
                     (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
     (with-mock
-     (mock (popup-menu* *) => "/test2.txt:52 var thing = function()")
+     (mock (popup-menu* *) => "/test2.txt:52: var thing = function()")
      (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
@@ -398,7 +398,7 @@
                     (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
     (with-mock
      (mock (helm-build-sync-source * :candidates * :persistent-action *))
-     (mock (helm * * :buffer "*helm dumb jump choices*") => "/test2.txt:52 var thing = function()")
+     (mock (helm * * :buffer "*helm dumb jump choices*") => "/test2.txt:52: var thing = function()")
      (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
@@ -411,7 +411,7 @@
          (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")
                     (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
     (with-mock
-     (mock (ivy-read * *)  => "/test2.txt:52 var thing = function()")
+     (mock (ivy-read * *)  => "/test2.txt:52: var thing = function()")
      (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
@@ -484,7 +484,7 @@
       (goto-char (point-min))
       (forward-char 13)
       (with-mock
-       (mock (popup-tip "/src/js/fake.js:3 function doSomeStuff() {"))
+       (mock (popup-tip "/src/js/fake.js:3: function doSomeStuff() {"))
        (should (string= go-js-file (dumb-jump-quick-look)))))))
 
 (ert-deftest dumb-jump-go-js2-test ()
@@ -755,7 +755,7 @@
 
 (ert-deftest dumb-jump-message-result-follow-tooltip-test ()
   (with-mock
-   (mock (popup-tip "/file.js:62 var isNow = true"))
+   (mock (popup-tip "/file.js:62: var isNow = true"))
    (let ((result '(:path "src/file.js" :line 62 :context "var isNow = true" :diff 7 :target "isNow")))
      (dumb-jump--result-follow result t "src"))))
 


### PR DESCRIPTION
These changes are meant to enable the creation of https://github.com/jtamagnan/counsel-dumb-jump
Which is a package that enables font-lock in the ivy completion buffer for dumb-search and also makes it so that the corresponding ivy-occur buffer is fully featured, as it would be if using `counsel-rg` or `swiper`. I would be willing to bring `counsel-dumb-jump` into `dumb-jump` but I thought that as this would add some dependencies it would be best for it to be its own seperate repo. I would love your opinion on this. 

 * dumb-jump.el: Modify format of choices to match emacs grep format.
   Create dumb-jump-ivy-jump-to-selected-function variable to allow
   users to customize how ivy should select a match

 * test/dumb-jump-test.el: Fix tests to match new format