### PR TITLE
thing-at-point 'sexp vs `symbol [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+
 script:
   - rg --version
   - ag --version

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1366,7 +1366,7 @@ to keep looking for another root."
    ((or (string= (buffer-name) "*shell*")
         (string= (buffer-name) "*eshell*"))
     (dumb-jump-fetch-shell-results prompt))
-   ((and (not prompt) (not (region-active-p)) (not (thing-at-point 'symbol)))
+   ((and (not prompt) (not (region-active-p)) (not (thing-at-point 'sexp)))
     (dumb-jump-issue-result "nosymbol"))
    (t
     (dumb-jump-fetch-file-results prompt))))
@@ -1412,8 +1412,8 @@ to keep looking for another root."
   (if (region-active-p)
       (buffer-substring-no-properties (region-beginning) (region-end))
     (if (version< emacs-version "24.4")
-        (thing-at-point 'symbol)
-      (thing-at-point 'symbol t))))
+        (thing-at-point 'sexp)
+      (thing-at-point 'sexp t))))
 
 (defun dumb-jump-get-lang-by-shell-contents (buffer)
   "Return languages in BUFFER by checking if file extension is mentioned."
@@ -1432,7 +1432,7 @@ LANG is a string programming langage with CONFIG a property list
 of project configuraiton."
   (let* ((cur-line (if prompt 0 (dumb-jump-get-point-line)))
          (look-for-start (when (not prompt)
-                           (- (car (bounds-of-thing-at-point 'symbol))
+                           (- (car (bounds-of-thing-at-point 'sexp))
                             (point-at-bol))))
          (cur-line-num (line-number-at-pos))
          (proj-config (dumb-jump-get-config proj-root))


### PR DESCRIPTION
Experiments related to #179 

I noticed that "things" `sexp` and `symbol` will behave differently with `thing-at-point` based on the current mode. Some example code below

```
(with-temp-buffer
  (funcall 'lisp-mode) ;; if removed or changed you can get different results for symbol vs sexp
  (let ((expected "#/something")) 
    (insert (concat "(" expected ")"))
    (goto-char (point-min))
    (forward-char 5)
    (let* ((cur (thing-at-point 'sexp)) ;; vs 'symbol
           (line (thing-at-point 'line))
           (matches (string= expected cur)))
           (message "thing: %s | matched: %s | line: %s" cur matches line))))
```

because of this I am considering adding two new options `dumb-jump-default-thing` and `dumb-jump-language-thing`. Where you can either define a "thing" per language or a default.

For anyone reading this please let me know if you have any feedback either way. Thanks!