### PR TITLE
fix line parsing error in dumb-jump-helm-persist-action

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1395,11 +1395,9 @@ Optionally pass t for RUN-NOT-TESTS to see a list of all failed rules"
 
 (defun dumb-jump-helm-persist-action (match)
   "Previews a MATCH in a temporary buffer at the matched line number when pressing \\<keymap>C-j</keymap> in helm."
-  (let* ((parts (--remove (string= it "")
-                          (s-split "\\(?:^\\|:\\)[0-9]+:"  match)))
-         (file-line-part (s-split ":" (nth 0 parts)))
-         (file (nth 0 file-line-part))
-         (line (string-to-number (nth 1 file-line-part)))
+  (let* ((line-parts (dumb-jump-parse-response-line match "."))
+         (file (nth 0 line-parts))
+         (line (string-to-number (nth 1 line-parts)))
          (default-directory-old default-directory))
     (switch-to-buffer (get-buffer-create " *helm dumb jump persistent*"))
     (setq default-directory default-directory-old)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -425,7 +425,7 @@
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
 (ert-deftest dumb-jump-prompt-user-for-choice-correct-helm-persistent-action-test ()
-  (dumb-jump-helm-persist-action "dumb-jump.el:1")
+  (dumb-jump-helm-persist-action "dumb-jump.el:1: (defn status")
   (should (get-buffer " *helm dumb jump persistent*")))
 
 (ert-deftest dumb-jump-prompt-user-for-choice-correct-ivy-test ()


### PR DESCRIPTION
Fix problem in parsing line removing the line-number portion during `s-split`.

```emacs-list
(let* ((match "vault.clj:222: (defn status")
       (parts (--remove (string= it "")
                        (s-split "\\(?:^\\|:\\([0-9]+\\):\\)"  match))))
  parts)
;;; => ("vault.clj" " (defn status")

```