### PR TITLE
Add basic support for jumping to functions in SQL files

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1044,6 +1044,25 @@ or most optimal searcher."
                    "CREATE PROCEDURE test (OUT p INT)"
                    "create definer = 'test'@'localhost' procedure test()"))
 
+    (:type "table" :supports ("ag" "grep" "rg" "git-grep") :language "sql"
+           :regex "(CREATE|create)\\s+(.+?\\s+)?(TABLE|table)(\\s+(IF NOT EXISTS|if not exists))?\\s+JJJ\\b"
+           :tests ("CREATE TABLE test ("
+                   "create temporary table if not exists test"
+                   "CREATE TABLE IF NOT EXISTS test ("
+                   "create global temporary table test"))
+
+    (:type "view" :supports ("ag" "grep" "rg" "git-grep") :language "sql"
+           :regex "(CREATE|create)\\s+(.+?\\s+)?(VIEW|view)\\s+JJJ\\b"
+           :tests ("CREATE VIEW test ("
+                   "create sql security definer view test"
+                   "CREATE OR REPLACE VIEW test AS foo"))
+
+    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "sql"
+           :regex "(CREATE|create)\\s+(.+?\\s+)?(TYPE|type)\\s+JJJ\\b"
+           :tests ("CREATE TYPE test"
+                   "CREATE OR REPLACE TYPE test AS foo ("
+                   "create type test as ("))
+
     ;; systemverilog
     (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "systemverilog"
            :regex "\\s*class\\s+\\bJJJ\\b"

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1036,6 +1036,14 @@ or most optimal searcher."
                    "functor test (T:TEST) ="
                    "functor test(T:TEST) ="))
 
+    ;; sql
+    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "sql"
+           :regex "(CREATE|create)\\s+(.+?\\s+)?(FUNCTION|function|PROCEDURE|procedure)\\s+JJJ\\s*\\\("
+           :tests ("CREATE FUNCTION test(i INT) RETURNS INT"
+                   "create or replace function test (int)"
+                   "CREATE PROCEDURE test (OUT p INT)"
+                   "create definer = 'test'@'localhost' procedure test()"))
+
     ;; systemverilog
     (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "systemverilog"
            :regex "\\s*class\\s+\\bJJJ\\b"
@@ -1212,6 +1220,7 @@ or most optimal searcher."
     (:language "shell" :ext "ksh" :agtype nil :rgtype nil)
     (:language "shell" :ext "tcsh" :agtype nil :rgtype nil)
     (:language "sml" :ext "sml" :agtype "sml" :rgtype "sml")
+    (:language "sql" :ext "sql" :agtype "sql" :rgtype "sql")
     (:language "swift" :ext "swift" :agtype nil :rgtype "swift")
     (:language "tex" :ext "tex" :agtype "tex" :rgtype "tex")
     (:language "elixir" :ext "ex" :agtype "elixir" :rgtype "elixir")


### PR DESCRIPTION
This is incredibly basic, and adds support for syntax generally defined by the SQL standard, with
provisions for syntax exposed by popular database engines, such as MySQL, PostgreSQL, MS-SQL etc.

Both upper-case and lower-case definitions will match. A better solution would'be been to allow for
case-insensitive matching, but mixed case within the same word should be rare enough to not be a
problem at this stage.