### PR TITLE
Simplify helm usage and fix persistent action

### DIFF
--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -419,13 +419,12 @@
          (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")
                     (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
     (with-mock
-     (mock (helm-build-sync-source * :candidates * :persistent-action *))
-     (mock (helm * * :buffer "*helm dumb jump choices*") => "/test2.txt:52: var thing = function()")
-     (mock (dumb-jump-result-follow '(:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a")))
+     (mock (helm-build-sync-source * :action * :candidates * :persistent-action *))
+     (mock (helm * * :buffer "*helm dumb jump choices*"))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 
 (ert-deftest dumb-jump-prompt-user-for-choice-correct-helm-persistent-action-test ()
-  (dumb-jump-helm-persist-action "dumb-jump.el:1: (defn status")
+  (dumb-jump-helm-persist-action '(:path "dumb-jump.el" :line 1 :context " (defn status"))
   (should (get-buffer " *helm dumb jump persistent*")))
 
 (ert-deftest dumb-jump-prompt-user-for-choice-correct-ivy-test ()


### PR DESCRIPTION
Before this commit, `dumb-jump-prompt-user-for-choice` would provide helm only with the formatted choices.  The persistent action would need to parse the selected choice, which did not always work properly because the path may be truncated in the formatted choice.

* `dumb-jump.el` (`dumb-jump-prompt-user-for-choice`): Instead of invoking `helm` and then invoking `dumb-jump-to-selected` on the result, invoke `helm` with a default action that invokes `dumb-jump-result-follow`.
Pass in the actual results along with the formatted choices so that actions have actual results to work with.

* `dumb-jump.el` (`dumb-jump-helm-persist-action`): Expect the actual result rather than the formatted choice.
Fix the doc string.

* `test/dumb-jump-test.el`
(`dumb-jump-prompt-user-for-choice-correct-helm-persistent-action-test`):
Adjust test input per the changes to `dumb-jump-helm-persist-action`.
