### PR TITLE
Add PHPDoc's @method and @property tag for PHP magic method

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -617,7 +617,7 @@ or most optimal searcher."
            :tests ("function test()" "function test ()"))
 
     (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "php"
-           :regex "\\*\\s@method\\s+\\S+\\s+JJJ\\("
+           :regex "\\*\\s@method\\s+[^ 	]+\\s+JJJ\\("
            :tests ("/** @method string|false test($a)" " * @method bool test()"))
 
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "php"
@@ -625,9 +625,8 @@ or most optimal searcher."
            :tests ("$test = 1234" "$foo->test = 1234"))
 
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "php"
-           :regex "\\*\\s@property(-read|-write)?\\s+(\\S+\\s+)&?\\$JJJ(\\s+|$)"
+           :regex "\\*\\s@property(-read|-write)?\\s+([^ 	]+\\s+)&?\\$JJJ(\\s+|$)"
            :tests ("/** @property string $test" "/** @property string $test description for $test property"  " * @property-read bool|bool $test" " * @property-write \\ArrayObject<string,resource[]> $test"))
-
     (:type "trait" :supports ("ag" "grep" "rg" "git-grep") :language "php"
            :regex "trait\\s*JJJ\\s*\\\{"
            :tests ("trait test{" "trait test {"))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -616,9 +616,17 @@ or most optimal searcher."
            :regex "function\\s*JJJ\\s*\\\("
            :tests ("function test()" "function test ()"))
 
+    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "php"
+           :regex "\\*\\s@method\\s+\\S+\\s+JJJ\\("
+           :tests ("/** @method string|false test($a)" " * @method bool test()"))
+
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "php"
            :regex "(\\s|->|\\$|::)JJJ\\s*=\\s*"
            :tests ("$test = 1234" "$foo->test = 1234"))
+
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "php"
+           :regex "\\*\\s@property(-read|-write)?\\s+(\\S+\\s+)&?\\$JJJ$"
+           :tests ("/** @property string $test" " * @property-read bool|bool $test" " * @property-write \\ArrayObject<string,resource[]> $test"))
 
     (:type "trait" :supports ("ag" "grep" "rg" "git-grep") :language "php"
            :regex "trait\\s*JJJ\\s*\\\{"

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -625,8 +625,8 @@ or most optimal searcher."
            :tests ("$test = 1234" "$foo->test = 1234"))
 
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "php"
-           :regex "\\*\\s@property(-read|-write)?\\s+(\\S+\\s+)&?\\$JJJ$"
-           :tests ("/** @property string $test" " * @property-read bool|bool $test" " * @property-write \\ArrayObject<string,resource[]> $test"))
+           :regex "\\*\\s@property(-read|-write)?\\s+(\\S+\\s+)&?\\$JJJ(\\s+|$)"
+           :tests ("/** @property string $test" "/** @property string $test description for $test property"  " * @property-read bool|bool $test" " * @property-write \\ArrayObject<string,resource[]> $test"))
 
     (:type "trait" :supports ("ag" "grep" "rg" "git-grep") :language "php"
            :regex "trait\\s*JJJ\\s*\\\{"


### PR DESCRIPTION
These notations are defined by phpDocumentor.

- http://docs.phpdoc.org/references/phpdoc/tags/method.html
- http://docs.phpdoc.org/references/phpdoc/tags/property.html