### PR TITLE
Add Rake extension for Ruby

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1270,6 +1270,7 @@ or most optimal searcher."
     (:language "ruby" :ext "rb" :agtype "ruby" :rgtype "ruby")
     (:language "ruby" :ext "erb" :agtype "ruby" :rgtype nil)
     (:language "ruby" :ext "haml" :agtype "ruby" :rgtype nil)
+    (:language "ruby" :ext "rake" :agtype "ruby" :rgtype nil)
     (:language "ruby" :ext "slim" :agtype "ruby" :rgtype nil)
     (:language "rust" :ext "rs" :agtype "rust" :rgtype "rust")
     (:language "scala" :ext "scala" :agtype "scala" :rgtype "scala")


### PR DESCRIPTION
Rake files in Ruby often use the `.rake` extension. (I think they could use `.rb` too, but that seems to be less common.)

For example: https://github.com/rails/rails/blob/master/railties/lib/rails/tasks/yarn.rake

https://medium.com/@rudyyazdi/rake-gem-explained-ebee7e6e6f72
