### PR TITLE
Find Fortran subroutines defined in interface blocks

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -671,6 +671,11 @@ or most optimal searcher."
            :tests ("function test (foo)" "integer function test(foo)" "subroutine test (foo, bar)")
            :not ("end function test" "end subroutine test"))
 
+    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "fortran"
+           :regex "^\\s*interface\\s+JJJ\\b"
+           :tests ("interface test")
+           :not ("interface test2" "end interface test"))
+
     (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "fortran"
            :regex "^\\s*module\\s+JJJ\\s*"
            :tests ("module test")


### PR DESCRIPTION
This finds generic procedures defined like this:

```Fortran
  interface endrun
     module procedure endrun_vanilla
     module procedure endrun_globalindex
  end interface
```

(where you're looking for the definition of 'endrun').

Since there is no instance of `subroutine endrun (...)` (only `subroutine endrun_vanilla (...)` and `subroutine endrun_globalindex (...)`), this change is needed in order to find the place where `endrun` is defined.