### PR TITLE
Call ivy-read canonically

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1628,7 +1628,11 @@ This is the persistent action (\\[helm-execute-persistent-action]) for helm."
   "Offer CHOICES as canidates through ivy-read then execute
 dumb-jump-to-selected on RESULTS CHOICES and selected choice.
 Ignore PROJ"
-  (dumb-jump-to-selected results choices (ivy-read "Jump to: " choices)))
+  (ivy-read "Jump to: " choices
+            :action
+            (lambda (selected)
+              (dumb-jump-to-selected results choices selected))
+            :caller 'dumb-jump-ivy-jump-to-selected))
 
 (defun dumb-jump-prompt-user-for-choice (proj results)
   "Put a PROJ's list of RESULTS in a 'popup-menu' (or helm/ivy)


### PR DESCRIPTION
I'd better suggest you pass an action function to `ivy-read` as `:action` argument rather than pass the result of `ivy-read` to the action. This allows navigating through candidates by `C-M-m` without closing the prompt. 

Setting `:caller` is also recommended, as it allows per-function customization of Ivy.