### PR TITLE
Perl: Support the new syntax of function declarations

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -624,8 +624,8 @@ or most optimal searcher."
 
     ;; perl
     (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "perl"
-           :regex "sub\\s*JJJ\\s*\\\{"
-           :tests ("sub test{" "sub test {"))
+           :regex "sub\\s*JJJ\\s*(\\{|\\()"
+           :tests ("sub test{" "sub test {" "sub test(" "sub test ("))
 
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "perl"
            :regex "JJJ\\s*=\\s*"


### PR DESCRIPTION
I've added the support for the new style function declarations with the argument list just after the function name. I also removed a stray backslash in the regex that was there: `\\\{` doesn't make sense in an Elisp string.