### PR TITLE
Ruby: support for fully qualified constants

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1751,7 +1751,7 @@ to keep looking for another root."
   (cond
    ((and (string= lang "clojure") (s-contains? "/" look-for))
     (nth 1 (s-split "/" look-for)))
-   ((and (or (string= lang "ruby") (string= lang "crystal")) (s-starts-with? ":" look-for))
+   ((and (or (string= lang "ruby") (string= lang "crystal")) (and (s-starts-with? ":" look-for) (and (not (s-starts-with? "::" look-for)))))
     (s-chop-prefix ":" look-for))
    ((and (string= lang "ruby") (s-contains? "::" look-for))
     (-last-item (s-split "::" look-for)))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1751,10 +1751,10 @@ to keep looking for another root."
   (cond
    ((and (string= lang "clojure") (s-contains? "/" look-for))
     (nth 1 (s-split "/" look-for)))
-   ((and (or (string= lang "ruby") (string= lang "crystal")) (and (s-starts-with? ":" look-for) (and (not (s-starts-with? "::" look-for)))))
-    (s-chop-prefix ":" look-for))
    ((and (string= lang "ruby") (s-contains? "::" look-for))
     (-last-item (s-split "::" look-for)))
+   ((and (or (string= lang "ruby") (string= lang "crystal")) (s-starts-with? ":" look-for))
+    (s-chop-prefix ":" look-for))
    ((and (string= lang "systemverilog") (s-starts-with? "`" look-for))
     (s-chop-prefix "`" look-for))
    (t

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -835,11 +835,13 @@
         (result2 (dumb-jump-process-symbol-by-lang "clojure" "myns/myfunc"))
         (result3 (dumb-jump-process-symbol-by-lang "ruby" ":myrubyfunc"))
         (result3b (dumb-jump-process-symbol-by-lang "ruby" "Health::Checks::QueueGrowth"))
+        (result3c (dumb-jump-process-symbol-by-lang "ruby" "::Health"))
         (result4 (dumb-jump-process-symbol-by-lang "systemverilog" "`myvlfunc")))
     (should (string= result "somefunc"))
     (should (string= result2 "myfunc"))
     (should (string= result3 "myrubyfunc"))
     (should (string= result3b "QueueGrowth"))
+    (should (string= result3c "Health"))
     (should (string= result4 "myvlfunc"))))
 
 (ert-deftest dumb-jump--result-follow-test ()


### PR DESCRIPTION
Adds support for fully qualified constants like "::Foo". Currently dumb-jump peeks at the first character of the symbol to see if it starts with a colon and thus is a ruby symbol, then strips the colon. This patch checks to see if the symbol starts with two colons and, if so, doesn't strip the colon.