### PR TITLE
Add nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ There is currently basic support for the following languages:
 * LaTeX
 * Lua
 * Nim
+* Nix
 * Objective-C
 * OCaml
 * Pascal

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -523,6 +523,12 @@ or most optimal searcher."
            :tests ("type test = object" "type test {.pure.} = enum")
            :not ("type testnot = object"))
 
+    ;; nix
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "nix"
+           :regex "^\\s*JJJ\\s=[^=;]+"
+           :tests ("test = 1234;" "test =\n123;")
+           :not ("testNot = 1234;"))
+
     ;; ruby
     (:type "variable" :supports ("ag" "rg" "git-grep") :language "ruby"
            :regex "^\\s*((\\w+[.])*\\w+,\\s*)*JJJ(,\\s*(\\w+[.])*\\w+)*\\s*=([^=>~]|$)"
@@ -1307,6 +1313,7 @@ or most optimal searcher."
     (:language "javascript" :ext "css" :agtype "css" :rgtype "css")
     (:language "lua" :ext "lua" :agtype "lua" :rgtype "lua")
     (:language "nim" :ext "nim" :agtype "nim" :rgtype "nim")
+    (:language "nix" :ext "nix" :agtype "nix" :rgtype "nix")
     (:language "org" :ext "org" :agtype nil :rgtype "org")
     (:language "perl" :ext "pl" :agtype "perl" :rgtype "perl")
     (:language "perl" :ext "pm" :agtype "perl" :rgtype "perl")
@@ -1964,6 +1971,7 @@ current file."
     (:comment "#" :language "ruby")
     (:comment "#" :language "crystal")
     (:comment "#" :language "nim")
+    (:comment "#" :language "nix")
     (:comment "//" :language "scala")
     (:comment ";" :language "scheme")
     (:comment "#" :language "shell")

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -524,10 +524,10 @@ or most optimal searcher."
            :not ("type testnot = object"))
 
     ;; nix
-    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "nix"
-           :regex "^\\s*JJJ\\s=[^=;]+"
+    (:type "variable" :supports ("ag" "rg") :language "nix"
+           :regex "\\b\\s*JJJ\\s*=[^=;]+"
            :tests ("test = 1234;" "test =\n123;")
-           :not ("testNot = 1234;"))
+           :not ("testNot = 1234;" "Nottest = 1234;" "AtestNot = 1234;"))
 
     ;; ruby
     (:type "variable" :supports ("ag" "rg" "git-grep") :language "ruby"

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -524,9 +524,9 @@ or most optimal searcher."
            :not ("type testnot = object"))
 
     ;; nix
-    (:type "variable" :supports ("ag" "rg") :language "nix"
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "nix"
            :regex "\\b\\s*JJJ\\s*=[^=;]+"
-           :tests ("test = 1234;" "test =\n123;")
+           :tests ("test = 1234;" "test = 123;" "test=123")
            :not ("testNot = 1234;" "Nottest = 1234;" "AtestNot = 1234;"))
 
     ;; ruby


### PR DESCRIPTION
This is very basic, but nix is also a very basic language. Everything is basically variables (definitions) and they could be either data or functions.

The recommended way to find definitions got me to think about this:
https://nixos.wiki/wiki/Nix_Expression_Language#Finding_a_.28function.2Fpackage.2F.E2.80.A6.29_definition

I haven't tested this much yet, but seems to work.