### PR TITLE
Fix git grep with default recurse submodules

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2522,7 +2522,7 @@ Using ag to search only the files found via git-grep literal symbol search."
          (cmd (concat dumb-jump-git-grep-cmd
                       " --color=never --line-number"
                       (if dumb-jump-git-grep-search-untracked
-                          " --untracked"
+                          " --untracked --no-recurse-submodules"
                         "")
                       " -E"))
          (fileexps (s-join " " (--map (shell-quote-argument (format "%s/*.%s" proj it)) ggtypes)))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -156,7 +156,7 @@
   (let* ((regexes (dumb-jump-get-contextual-regexes "elisp" nil 'git-grep))
          (expected-regexes "\\((defun|cl-defun)\\s+tester($|[^a-zA-Z0-9\\?\\*-])|\\(defvar\\b\\s*tester($|[^a-zA-Z0-9\\?\\*-])|\\(defcustom\\b\\s*tester($|[^a-zA-Z0-9\\?\\*-])|\\(setq\\b\\s*tester($|[^a-zA-Z0-9\\?\\*-])|\\(tester\\s+|\\((defun|cl-defun)\\s*.+\\(?\\s*tester($|[^a-zA-Z0-9\\?\\*-])\\s*\\)?")
          (excludes '("one" "two" "three"))
-         (expected (concat "git grep --color=never --line-number --untracked -E " (shell-quote-argument expected-regexes) " -- ./\\*.el ./\\*.el.gz \\:\\(exclude\\)one \\:\\(exclude\\)two \\:\\(exclude\\)three")))
+         (expected (concat "git grep --color=never --line-number --untracked --no-recurse-submodules -E " (shell-quote-argument expected-regexes) " -- ./\\*.el ./\\*.el.gz \\:\\(exclude\\)one \\:\\(exclude\\)two \\:\\(exclude\\)three")))
     (should (string= expected  (dumb-jump-generate-git-grep-command  "tester" "blah.el" "." regexes "elisp" excludes)))))
 
 (ert-deftest dumb-jump-generate-git-grep-command-not-search-untracked-test ()


### PR DESCRIPTION
`git grep`'s `--untracked` argument is incompatible with `--recurse-submodules` and the `.gitconfig` option `submodule.recurse = true` makes `--recurse-submodules` the default.

As a result if you have `submodule.recurse = true` in your `.gitconfig`, dumb jump will silently fail to work in any git repository that has submodules checked out, unless you disable `dumb-jump-git-grep-search-untracked`. This change makes `dumb-jump-git-grep-search-untracked` imply `--no-recurse-submodules`, which will defeat the config option and make it work, albeit ignoring the content of the submodules.