### PR TITLE
add a `dumb-jump-git-grep-search-untracked-args` option

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -214,6 +214,13 @@ or most optimal searcher."
   :group 'dumb-jump
   :type 'boolean)
 
+(defcustom dumb-jump-git-grep-search-untracked-args
+  " --untracked"
+  "If dumb-jump-git-grep-search-untracked is non-nil Dumb Jump will add these arguments."
+  :group 'dumb-jump
+  :type 'string)
+
+
 (defcustom dumb-jump-find-rules
   '((:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "elisp"
            :regex "\\\((defun|cl-defun)\\s+JJJ\\j"
@@ -2522,7 +2529,7 @@ Using ag to search only the files found via git-grep literal symbol search."
          (cmd (concat dumb-jump-git-grep-cmd
                       " --color=never --line-number"
                       (if dumb-jump-git-grep-search-untracked
-                          " --untracked"
+                          dumb-jump-git-grep-search-untracked-args
                         "")
                       " -E"))
          (fileexps (s-join " " (--map (shell-quote-argument (format "%s/*.%s" proj it)) ggtypes)))

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -159,6 +159,15 @@
          (expected (concat "git grep --color=never --line-number --untracked -E " (shell-quote-argument expected-regexes) " -- ./\\*.el ./\\*.el.gz \\:\\(exclude\\)one \\:\\(exclude\\)two \\:\\(exclude\\)three")))
     (should (string= expected  (dumb-jump-generate-git-grep-command  "tester" "blah.el" "." regexes "elisp" excludes)))))
 
+(ert-deftest dumb-jump-generate-git-grep-command-no-ctx-untracked-override ()
+  ;; --recurse-submodules
+  (let* ((regexes (dumb-jump-get-contextual-regexes "elisp" nil 'git-grep))
+         (expected-regexes "\\((defun|cl-defun)\\s+tester($|[^a-zA-Z0-9\\?\\*-])|\\(defvar\\b\\s*tester($|[^a-zA-Z0-9\\?\\*-])|\\(defcustom\\b\\s*tester($|[^a-zA-Z0-9\\?\\*-])|\\(setq\\b\\s*tester($|[^a-zA-Z0-9\\?\\*-])|\\(tester\\s+|\\((defun|cl-defun)\\s*.+\\(?\\s*tester($|[^a-zA-Z0-9\\?\\*-])\\s*\\)?")
+         (excludes '("one" "two" "three"))
+         (dumb-jump-git-grep-search-untracked-args " --untracked --recurse-submodules")
+         (expected (concat "git grep --color=never --line-number --untracked --recurse-submodules -E " (shell-quote-argument expected-regexes) " -- ./\\*.el ./\\*.el.gz \\:\\(exclude\\)one \\:\\(exclude\\)two \\:\\(exclude\\)three")))
+    (should (string= expected  (dumb-jump-generate-git-grep-command  "tester" "blah.el" "." regexes "elisp" excludes)))))
+
 (ert-deftest dumb-jump-generate-git-grep-command-not-search-untracked-test ()
   (let* ((dumb-jump-git-grep-search-untracked nil)
          (regexes (dumb-jump-get-contextual-regexes "elisp" nil 'git-grep))


### PR DESCRIPTION
For #267, the solution would be:

 `(setq dumb-jump-git-grep-search-untracked-args " --untracked --recurse-submodules")`