### PR TITLE
Separate filtering from handling

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2039,7 +2039,7 @@ RESULTS is a property list with the search's results.
 PREFER-EXTERNAL-P will sort the current file last.
 USE-TOOLTIP-P shows a preview instead of jumping."
   (let ((filtered (dumb-jump-filter-results results prefer-external-p)))
-  (when dumb-jump-debug
+    (when dumb-jump-debug
       (dumb-jump-message "-----\nDUMB JUMP DEBUG `dumb-jump-handle-results` START\n----- \n\nlook for:\n\t%s\n\ntype:\n\t%s\n\njump?\n\t%s\n\nresults:\n\t%s\n\nprefer external:\n\t%s\n\nproj-root:\n\t%s\n\ncur-file:\n\t%s\n\n-----\nDUMB JUMP DEBUG `dumb-jump-handle-results` END\n-----\n"
                          (plist-get results :symbol)
                          (plist-get results :ctx-type)
@@ -2048,11 +2048,16 @@ USE-TOOLTIP-P shows a preview instead of jumping."
                          prefer-external-p
                          (plist-get results :root)
                          (plist-get results :cur-file)))
-    (if (and filtered
-             (or dumb-jump-aggressive
-                 (= (length filtered) 1)))
-        (dumb-jump-result-follow (car filtered) use-tooltip-p (plist-get results :root))
-      (dumb-jump-prompt-user-for-choice (plist-get results :root) filtered))))
+    (cond (use-tooltip-p
+           (popup-menu* (mapcar (lambda (result)
+                                  (dumb-jump--format-result (plist-get results :root) result))
+                                filtered)))
+          ((and filtered
+                (or dumb-jump-aggressive
+                    (= (length filtered) 1)))
+           (dumb-jump-result-follow (car filtered) use-tooltip-p (plist-get results :root)))
+          (t
+           (dumb-jump-prompt-user-for-choice (plist-get results :root) filtered)))))
 
 (defun dumb-jump-filter-results (results &optional prefer-external-p)
   "Filters results.  Removes comments and sorts by the following order:

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1967,8 +1967,7 @@ current file."
      ((> result-count 1)
       ;; multiple results so let the user pick from a list
       ;; unless the match is in the current file
-      (dumb-jump-handle-results results (plist-get info :file) proj-root (plist-get info :ctx-type)
-                                look-for use-tooltip prefer-external))
+      (dumb-jump-handle-results info prefer-external use-tooltip))
      ((= result-count 0)
       (dumb-jump-message "'%s' %s %s declaration not found." look-for (if (s-blank? lang) "with unknown language so" lang) (plist-get info :ctx-type))))))
 
@@ -2034,99 +2033,54 @@ given the LANG of the current file."
          (--filter (not (s-starts-with? comment (s-trim (plist-get it :context)))) results))
       results)))
 
-(defun dumb-jump-handle-results
-    (results cur-file proj-root ctx-type look-for use-tooltip prefer-external)
-  "Handle the searchers results.
-RESULTS is a list of property lists with the searcher's results.
-CUR-FILE is the current file within PROJ-ROOT.
-CTX-TYPE is a string of the current context.
-LOOK-FOR is the symbol we're jumping for.
-USE-TOOLTIP shows a preview instead of jumping.
-PREFER-EXTERNAL will sort current file last."
-  "Figure which of the RESULTS to jump to. Favoring the CUR-FILE"
-  (let* ((lang (dumb-jump-get-language-by-filename cur-file))
-         (match-sorted (-sort (lambda (x y) (< (plist-get x :diff) (plist-get y :diff))) results))
-         (match-no-comments (dumb-jump-filter-no-start-comments match-sorted lang))
+(defun dumb-jump-handle-results (results &optional prefer-external-p use-tooltip-p)
+  "Handles the search results.
+RESULTS is a property list with the search's results.
+PREFER-EXTERNAL-P will sort the current file last.
+USE-TOOLTIP-P shows a preview instead of jumping."
+  (let ((filtered (dumb-jump-filter-results results prefer-external-p)))
+  (when dumb-jump-debug
+      (dumb-jump-message "-----\nDUMB JUMP DEBUG `dumb-jump-handle-results` START\n----- \n\nlook for:\n\t%s\n\ntype:\n\t%s\n\njump?\n\t%s\n\nresults:\n\t%s\n\nprefer external:\n\t%s\n\nproj-root:\n\t%s\n\ncur-file:\n\t%s\n\n-----\nDUMB JUMP DEBUG `dumb-jump-handle-results` END\n-----\n"
+                         (plist-get results :symbol)
+                         (plist-get results :ctx-type)
+                         (car filtered)
+                         (pp-to-string filtered)
+                         prefer-external-p
+                         (plist-get results :root)
+                         (plist-get results :cur-file)))
+    (if (and filtered
+             (or dumb-jump-aggressive
+                 (= (length filtered) 1)))
+        (dumb-jump-result-follow (car filtered) use-tooltip-p (plist-get results :root))
+      (dumb-jump-prompt-user-for-choice (plist-get results :root) filtered))))
 
-         ;; Find the relative current file path by the project root. In some cases the results will
-         ;; not be absolute but relative and the "current file" filters must match in both
-         ;; cases. Also works when current file is in an arbitrary sub folder.
-         (rel-cur-file
-          (cond ((and (s-starts-with? proj-root cur-file)
-                      (s-starts-with? default-directory cur-file))
-                 (substring cur-file (length default-directory) (length cur-file)))
-
-                ((and (s-starts-with? proj-root cur-file)
-                      (not (s-starts-with? default-directory cur-file)))
-                 (substring cur-file (1+ (length proj-root)) (length cur-file)))
-
-                (t
-                 cur-file)))
-
-         ;; Moves current file results to the front of the list, unless PREFER-EXTERNAL then put
-         ;; them last.
-         (match-cur-file-front
-          (if (not prefer-external)
-              (-concat
-               (--filter (and (> (plist-get it :diff) 0)
-                              (or (string= (plist-get it :path) cur-file)
-                                  (string= (plist-get it :path) rel-cur-file)))
-                         match-no-comments)
-               (--filter (and (<= (plist-get it :diff) 0)
-                              (or (string= (plist-get it :path) cur-file)
-                                  (string= (plist-get it :path) rel-cur-file)))
-                         match-no-comments)
-
-               ;; Sort non-current files by path length so the nearest file is more likely to be
-               ;; sorted higher to the top. Also sorts by line number for sanity.
-               (-sort (lambda (x y)
-                        (and (< (plist-get x :line) (plist-get y :line))
-                             (< (length (plist-get x :path)) (length (plist-get y :path)))))
-                      (--filter (not (or (string= (plist-get it :path) cur-file)
-                                         (string= (plist-get it :path) rel-cur-file)))
-                                match-no-comments)))
-            (-concat
-             (-sort (lambda (x y)
-                      (and (< (plist-get x :line) (plist-get y :line))
-                           (< (length (plist-get x :path)) (length (plist-get y :path)))))
-                    (--filter (not (or (string= (plist-get it :path) cur-file)
-                                       (string= (plist-get it :path) rel-cur-file)))
-                              match-no-comments))
-             (--filter (or (string= (plist-get it :path) cur-file)
-                           (string= (plist-get it :path) rel-cur-file))
-                       match-no-comments))))
-
-         (matches
-          (if (not prefer-external)
-              (-distinct
-               (append (dumb-jump-current-file-results cur-file match-cur-file-front)
-                       (dumb-jump-current-file-results rel-cur-file match-cur-file-front)))
-            match-cur-file-front))
-
-         (var-to-jump (car matches))
-         ;; TODO: handle if ctx-type is null but ALL results are variable
-
-         ;; When non-aggressive it should only jump when there is only one match, regardless of
-         ;; context.
-         (do-var-jump
-          (and (or dumb-jump-aggressive
-                   (= (length match-cur-file-front) 1))
-               (or (= (length matches) 1)
-                   (string= ctx-type "variable")
-                   (string= ctx-type ""))
-               var-to-jump)))
-
-    (when dumb-jump-debug
-      (dumb-jump-message
-       "-----\nDUMB JUMP DEBUG `dumb-jump-handle-results` START\n----- \n\nlook for: \n\t%s\n\ntype: \n\t%s \n\njump? \n\t%s \n\nmatches: \n\t%s \n\nresults: \n\t%s \n\nprefer external: \n\t%s\n\nmatch-cur-file-front: \n\t%s\n\nproj-root: \n\t%s\n\ncur-file: \n\t%s\n\nreal-cur-file: \n\t%s \n\n-----\nDUMB JUMP DEBUG `dumb-jump-handle-results` END\n-----\n"
-       look-for ctx-type var-to-jump (pp-to-string match-cur-file-front) (pp-to-string results) prefer-external match-cur-file-front proj-root cur-file rel-cur-file))
-    (cond
-     (use-tooltip ;; quick-look mode
-      (popup-menu* (--map (dumb-jump--format-result proj-root it) results)))
-     (do-var-jump
-        (dumb-jump-result-follow var-to-jump use-tooltip proj-root))
-     (t
-      (dumb-jump-prompt-user-for-choice proj-root match-cur-file-front)))))
+(defun dumb-jump-filter-results (results &optional prefer-external-p)
+  "Filters results.  Removes comments and sorts by the following order:
+same file vs other file, path distance, file name, and line."
+  (cl-flet ((compute-path-distance (file current-file)
+              (if (string= file current-file)
+                  0
+                (let ((first-diff (1- (abs (compare-strings file nil nil current-file nil nil)))))
+                  (1+ (cl-count ?/ (substring file first-diff)))))))
+    (let ((current-file (plist-get results :file)))
+      (sort (dumb-jump-filter-no-start-comments (plist-get results :results) (plist-get results :lang))
+            (lambda (lhs rhs)
+              (let* ((lhs-file (expand-file-name (plist-get lhs :path)))
+                     (lhs-current-file-p (string= lhs-file current-file))
+                     (lhs-path-distance (compute-path-distance lhs-file current-file))
+                     (rhs-file (expand-file-name (plist-get rhs :path)))
+                     (rhs-current-file-p (string= rhs-file current-file))
+                     (rhs-path-distance (compute-path-distance rhs-file current-file)))
+                (if (eq lhs-current-file-p rhs-current-file-p)
+                    (if (= lhs-path-distance rhs-path-distance)
+                        (if (string= lhs-file rhs-file)
+                            (<= (plist-get lhs :line)
+                                (plist-get rhs :line))
+                          (string< lhs-file rhs-file))
+                      (< lhs-path-distance rhs-path-distance))
+                  (if prefer-external-p
+                      (not lhs-current-file-p)
+                    lhs-current-file-p))))))))
 
 (defun dumb-jump-read-config (root config-file)
   "Load and return options (exclusions, inclusions, etc).
@@ -2226,11 +2180,6 @@ Ffrom the ROOT project CONFIG-FILE."
   (forward-char pos)
   (with-demoted-errors "Error running `dumb-jump-after-jump-hook': %S"
     (run-hooks 'dumb-jump-after-jump-hook)))
-
-(defun dumb-jump-current-file-results (path results)
-  "Return the PATH's RESULTS."
-  (let ((matched (--filter (string= path (plist-get it :path)) results)))
-    matched))
 
 (defun dumb-jump-generators-by-searcher (searcher)
   "For a SEARCHER it yields a response parser, a command

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2599,5 +2599,6 @@ Using ag to search only the files found via git-grep literal symbol search."
   :global t
   :keymap dumb-jump-mode-map)
 
+
 (provide 'dumb-jump)
 ;;; dumb-jump.el ends here

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -41,11 +41,6 @@
     (should (string= lang1b "php"))
     (should (string= lang2 "javascript"))))
 
-(ert-deftest dumb-jump-current-files-results-test ()
-  (let ((results '((:path "blah") (:path "rarr")))
-        (expected '((:path "blah"))))
-    (should (equal (dumb-jump-current-file-results "blah" results) expected))))
-
 (ert-deftest dumb-jump-exclude-path-test ()
   (let* ((expected (list (f-join test-data-dir-proj1 "ignored")
                          (f-join test-data-dir-proj1 "ignored2")))


### PR DESCRIPTION
This change tries to separate filtering from handling in `dumb-jump-handle-results` in order to facilitate #262. The filtering code received a big refactoring and a small change in behaviour, specifically in the order files are shown.

Although I ran some very basic tests this needs proper testing. Does the project have tests I can run against?

I might have introduced some bugs in `dumb-jump-handle-results` since I couldn't understand the jumping logic very well.