### PR TITLE
Remove duplicates from raw-results

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1893,7 +1893,10 @@ of project configuraiton."
                                               cur-line-num parse-fn generate-fn)
                        search-paths))
 
-         (results (--map (plist-put it :target look-for) raw-results)))
+         (results
+          (remove-duplicates
+           (--map (plist-put it :target look-for) raw-results)
+           :test (lambda (x y) (or (null y) (equal x y))))))
 
     `(:results ,results :lang ,(if (null lang) "" lang) :symbol ,look-for :ctx-type ,(if (null ctx-type) "" ctx-type) :file ,cur-file :root ,proj-root)))
 


### PR DESCRIPTION
Hello,

I do not know if this behavior comes from my configuration (I've only changed the dumb-jump-project-denoters, as having multiple Makefile is common for me, and it breaks to find the project root).

Anyway, with my current version of dumb-jump (dumb-jump-20190327.1727) the results contains most of the time duplicates. See picture:
![Screenshot from 2019-07-29 14-01-34](https://user-images.githubusercontent.com/5786186/62047631-3e3bc680-b20b-11e9-8681-d3e49936694f.png)

With this patch, it seems to have my expected behavior.

Disclaimer: I know nothing about elisp, so feel free to guide me for a better patch if necessary.