### PR TITLE
Remove possible duplicates in raw-results

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1893,7 +1893,7 @@ of project configuraiton."
                                               cur-line-num parse-fn generate-fn)
                        search-paths))
 
-         (results (--map (plist-put it :target look-for) raw-results)))
+         (results (delete-dups (--map (plist-put it :target look-for) raw-results))))
 
     `(:results ,results :lang ,(if (null lang) "" lang) :symbol ,look-for :ctx-type ,(if (null ctx-type) "" ctx-type) :file ,cur-file :root ,proj-root)))
 


### PR DESCRIPTION
So, second round (really sorry for the first one).

With this function `delete-dups` and the documentation is here:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Sets-And-Lists.html

As far as I understand, this should be part of the core library (but I don't know if that the case for all versions of emacs, mine is `GNU Emacs 25.3.2`).

Can someone double check or I will be too ashamed?