### PR TITLE
Add option to jump to modified buffers without confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ If you want to stop a directory from registering as the project root (and have D
 
 * `(setq dumb-jump-default-project "~/code")` to change default project if one is not found (defaults to `~`)
 * `(setq dumb-jump-quiet t)` if Dumb Jump is too chatty.
+* `(setq dumb-jump-confirm-jump-to-modified-file nil)` to avoid being prompted for confirmation if you attempt to jump to a file that has been modified and not saved.  This defaults to `t` because jumping to modified files results in you jumping to a location that may no longer be current.
 * To support more languages and/or definition types customize `dumb-jump-find-rules` variable.
 * `(add-hook 'dumb-jump-after-jump-hook 'some-function)` to execute code after you jump
 * `(setq dumb-jump-selector 'ivy)` to use [ivy](https://github.com/abo-abo/swiper#ivy) instead of the default popup for multiple options.


### PR DESCRIPTION
Thanks for the dumb-jump—it's a great package and the simplicity really appeals to me.  This is a PR for a patch that I find personally useful and thought others might as well.

It adds the option to jump directly to a buffer without being prompted for confirmation, even if that buffer is modified.  I find that this is more often what I want, especially when jumping back up to the definition of a function defined earlier in the file (which, if I have been editing lower in the file, won't have moved at all).

Specifically, if the `dumb-jump-confirm-jump-to-modified-file` variable is nil, then jumping to a modified buffer will print a warning message but will not wait for confirmation.

I also revised the README to explain this additional option. 