### PR TITLE
add basic matlab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Dumb Jump GIF](media/dumb-jump-example-v2.gif?raw=true)
 
 ## About
-**Dumb Jump** is an Emacs "jump to definition" package with support for multiple programming languages that favors "just working". This means minimal -- and ideally zero -- configuration with absolutely no stored indexes (TAGS) or persistent background processes. Dumb Jump requires at least GNU Emacs `24.3`.
+**Dumb Jump** is an Emacs "jump to definition" package with support for 40+ programming languages that favors "just working". This means minimal -- and ideally zero -- configuration with absolutely no stored indexes (TAGS) or persistent background processes. Dumb Jump requires at least GNU Emacs `24.3`.
 
 
 #### How  it works

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There is currently basic support for the following languages:
 * Julia
 * LaTeX
 * Lua
+* Matlab
 * Nim
 * Nix
 * Objective-C

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1362,6 +1362,8 @@ or most optimal searcher."
     (:language "javascript" :ext "css" :agtype "css" :rgtype "css")
     (:language "dart" :ext "dart" :agtype nil :rgtype "dart")
     (:language "lua" :ext "lua" :agtype "lua" :rgtype "lua")
+    ;; the extension "m" is also used by obj-c so must use matlab-mode
+    ;; since obj-c will win by file extension, but here for searcher types
     (:language "matlab" :ext "m" :agtype "matlab" :rgtype "matlab")
     (:language "nim" :ext "nim" :agtype "nim" :rgtype "nim")
     (:language "nix" :ext "nix" :agtype "nix" :rgtype "nix")

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -35,7 +35,7 @@
 (ert-deftest dumb-jump-get-lang-major-mode-test ()
   (let* ((major-mode 'php)
          (lang1 (dumb-jump-get-language "blah/file.install"))
-         (lang1b (dumb-jump-get-language-from-mode))
+         (lang1b (dumb-jump-get-mode-base-name))
          (lang2 (dumb-jump-get-language-by-filename "/askdfjkl/somefile.js")))
     (should (string= lang1 "php"))
     (should (string= lang1b "php"))


### PR DESCRIPTION
Adds basic matlab support. Must use `matlab-mode` since `.m` is also used by objective-c so normal language detection will not work