### PR TITLE
Add support for OpenSCAD scad files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There is currently basic support for the following languages:
 * Nix
 * Objective-C
 * OCaml
+* OpenSCAD
 * Pascal
 * Perl
 * PHP

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -642,6 +642,18 @@ or most optimal searcher."
            :regex "(^|[^\\w.])alias\\s+(\\w*::)*JJJ($|[^\\w|:])"
            :tests ("alias test" "alias Foo::test"))
 
+    ;; scad
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "scad"
+           :regex "\\s*\\bJJJ\\s*=[^=\\n]+" :tests ("test = 1234") :not ("if test == 1234 {"))
+
+    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "scad"
+           :regex "function\\s*JJJ\\s*\\\("
+           :tests ("function test()" "function test ()"))
+
+    (:type "module" :supports ("ag" "grep" "rg" "git-grep") :language "scad"
+           :regex "module\\s*JJJ\\s*\\\("
+           :tests ("module test()" "module test ()"))
+
     ;; scala
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "scala"
            :regex "\\bval\\s*JJJ\\s*=[^=\\n]+" :tests ("val test = 1234") :not ("case test => 1234"))
@@ -1397,6 +1409,7 @@ or most optimal searcher."
     (:language "ruby" :ext "rake" :agtype "ruby" :rgtype nil)
     (:language "ruby" :ext "slim" :agtype "ruby" :rgtype nil)
     (:language "rust" :ext "rs" :agtype "rust" :rgtype "rust")
+    (:language "scad" :ext "scad" :agtype nil :rgtype nil)
     (:language "scala" :ext "scala" :agtype "scala" :rgtype "scala")
     (:language "scheme" :ext "scm" :agtype "scheme" :rgtype "lisp")
     (:language "scheme" :ext "ss" :agtype "scheme" :rgtype "lisp")


### PR DESCRIPTION
OpenSCAD is a 3D modelling tool at: https://www.openscad.org/

In emacs, we can use http://melpa.org/#/scad-mode to assist editing, but it's nice to have dumb-jump providing definition jumping, so here we go.