### PR TITLE
Point byte-compiler to ivy-read and helm-make-source.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ test: unit
 unit:
 	${CASK} exec ert-runner
 
+compile:
+	${CASK} exec emacs -batch -L . -f batch-byte-compile dumb-jump.el
+
 install:
 	${CASK} install
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1961,6 +1961,8 @@ This is the persistent action (\\[helm-execute-persistent-action]) for helm."
           (plist-get result :line)
           (s-trim (plist-get result :context))))
 
+(declare-function ivy-read "ext:ivy")
+
 (defun dumb-jump-ivy-jump-to-selected (results choices _proj)
   "Offer CHOICES as candidates through `ivy-read', then execute
 `dumb-jump-result-follow' on the selected choice.  Ignore _PROJ."
@@ -1968,6 +1970,9 @@ This is the persistent action (\\[helm-execute-persistent-action]) for helm."
             :action (lambda (cand)
                       (dumb-jump-result-follow (cdr cand)))
             :caller 'dumb-jump-ivy-jump-to-selected))
+
+(declare-function helm "ext:helm")
+(declare-function helm-build-sync-source "ext:helm-source" nil t)
 
 (defun dumb-jump-prompt-user-for-choice (proj results)
   "Put a PROJ's list of RESULTS in a 'popup-menu' (or helm/ivy)
@@ -2444,6 +2449,9 @@ PREFER-EXTERNAL will sort current file last."
           :do-var-jump do-var-jump
           :var-to-jump var-to-jump
           :match-cur-file-front match-cur-file-front)))
+
+(declare-function tramp-dissect-file-name "tramp")
+(declare-function tramp-file-name-localname "tramp" nil t)
 
 (defun dumb-jump-read-config (root config-file)
   "Load and return options (exclusions, inclusions, etc).


### PR DESCRIPTION
`declare-function` should be used to tell the byte-compiler where to look.

`helm-make-source` is preferred over `helm-build-sync-source` for packages with an optional Helm dependency using `declare-function` in this manner since `declare-function` doesn't work on macros.

I don't know much about Tramp, so I'm not sure if it's necessary to add in `(require 'tramp)` where the `tramp-` functions get invoked. Maybe I should add in the `require`s anyway, they shouldn't hurt.

At the time of writing, the `master` branch fails a test for me (related to my last PR) when I run `cask` followed by `make test-in-docker`, which was strange since it passed on Travis when I submitted. Locally, this new PR fails one additional test for me: it still expects `helm-build-sync-source`, even after I've changed the test accordingly. I hope the CI receives this PR kindly.