### PR TITLE
Clarify that rg 0.10.0 is OK for multi-line method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you want to stop a directory from registering as the project root (and have D
 * `(setq dumb-jump-ag-search-args "")` to set additional command line arguments when using ag for searching (defaults to `""`).
 * `(setq dumb-jump-rg-search-args "")` to set additional command line arguments when using rg for searching (defaults to `"--pcre2"`).
 
-#### If your project has multi-line method signatures [you should use `ag`](https://github.com/jacktasia/dumb-jump/issues/129) or [`rg` with a version higher than `0.10`](https://github.com/jacktasia/dumb-jump/issues/255).
+#### If your project has multi-line method signatures [you should use `ag`](https://github.com/jacktasia/dumb-jump/issues/129) or [`rg` version `0.10.0` or higher](https://github.com/jacktasia/dumb-jump/issues/255).
 
 To learn more about how Dumb Jump picks a searcher see [this issue](https://github.com/jacktasia/dumb-jump/issues/109) and this [pull request](https://github.com/jacktasia/dumb-jump/pull/111).
 


### PR DESCRIPTION
The formulation "If your project has multi-line method signatures you should use ag or rg with a version **higher than 0.10**" made me think that my installed rg 0.10.0 was too old, but if I understand correctly 0.10.0 is fine since that's when multi-line support was added.