### PR TITLE
only allow one -G arg when using ag

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1450,6 +1450,7 @@ or most optimal searcher."
     (:language "ocaml" :ext "mli" :agtype "ocaml" :rgtype "ocaml")
     (:language "ocaml" :ext "mll" :agtype "ocaml" :rgtype "ocaml")
     (:language "ocaml" :ext "mly" :agtype "ocaml" :rgtype "ocaml")
+    ;; groovy is nil type because jenkinsfile is not in searcher type lists
     (:language "groovy" :ext "gradle" :agtype nil :rgtype nil)
     (:language "groovy" :ext "groovy" :agtype nil :rgtype nil)
     (:language "groovy" :ext "jenkinsfile" :agtype nil :rgtype nil)
@@ -2671,7 +2672,10 @@ searcher symbol."
                         (concat " " dumb-jump-ag-search-args))
                       (if agtypes
                           (s-join "" (--map (format " --%s" it) agtypes))
-                        (s-join "" (--map (format " -G '\\.%s$'" it) lang-exts)))))
+                        ;; there can only be one `-G` arg
+                        (concat " -G '("
+                                (s-join "|" (--map (format "\\.%s" it) lang-exts))
+                                ")$'"))))
          (exclude-args (dumb-jump-arg-joiner
                         "--ignore-dir" (--map (shell-quote-argument (s-replace proj-dir "" it)) exclude-paths)))
          (regex-args (shell-quote-argument (s-join "|" filled-regexes))))


### PR DESCRIPTION
This PR fixes a bug where multiple `-G` arguments were being passed to `ag` when it only allows one. This scenario would only happen when a language had multiple file extensions, AND there was no `agtype`, or we decided not to use it because we wanted to support more file extensions then `ag` includes in its list for a given language.

For most languages, we use the `agtype` so this wouldn't surface much, but was definitely an issue for Groovy: #320 #274 