### PR TITLE
Correctly jump to PHP function definitions and class definitions.

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1580,6 +1580,8 @@ or most optimal searcher."
     (:language "javascript" :type "variable" :right "^;" :left nil)
     (:language "typescript" :type "function" :right "^(" :left nil)
     (:language "perl" :type "function" :right "^(" :left nil)
+    (:language "php" :type "function" :right "^(" :left nil)
+    (:language "php" :type "class" :right nil :left "new\s+")
     (:language "elisp" :type "function" :right nil :left "($")
     (:language "elisp" :type "variable" :right "^)" :left nil)
     (:language "scheme" :type "function" :right nil :left "($")


### PR DESCRIPTION
Previously, variable definitions were shown when trying to jump to a
PHP function definition.

Definining a function context alone breaks jumps to class definitions
from constructors, so a class context needs to be defined as well.

Resolves: https://github.com/jacktasia/dumb-jump/issues/322