### PR TITLE
Jump to definition even though it took long to find it

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2131,11 +2131,11 @@ current file."
          (issue (plist-get info :issue))
          (lang (plist-get info :lang))
          (result-count (length results)))
-    (cond
-     ((> fetch-time dumb-jump-max-find-time)
+    (when (> fetch-time dumb-jump-max-find-time)
       (dumb-jump-message
        "Took over %ss to find '%s'. Please install ag or rg, or add a .dumbjump file to '%s' with path exclusions"
        (number-to-string dumb-jump-max-find-time) look-for proj-root))
+    (cond
      ((eq issue 'nogrep)
       (dumb-jump-message "Please install ag, rg, git grep or grep!"))
      ((eq issue 'nosymbol)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -715,9 +715,10 @@
       (goto-char (point-min))
       (noflet ((dumb-jump-fetch-file-results (&optional prompt)
                  (sleep-for 0 300)
-                 '()))
+                 '(:results (:result))))
         (with-mock
           (mock (dumb-jump-message "Took over %ss to find '%s'. Please install ag or rg, or add a .dumbjump file to '%s' with path exclusions" * * *))
+          (mock (dumb-jump-result-follow * * *))
           (dumb-jump-go))))))
 
 (ert-deftest dumb-jump-message-handle-results-test ()


### PR DESCRIPTION
The search process is not interrupted after `dumb-jump-max-find-time`
seconds but continues until all relevant files are searched for. Because of
that, it seams to be a waste to just print a message that the search took long
and do not jump to the found definition, if any.

This commit ensures that if any definition is found, we jump to it besides
printing the warning about the long search time.