### PR TITLE
Add completing-read to dumb-jump-selector

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -66,7 +66,7 @@
   :type '(choice (const :tag "Popup" popup)
                  (const :tag "Helm" helm)
                  (const :tag "Ivy" ivy)
-				 (const :tag "Completing Read" completing-read)))
+                 (const :tag "Completing Read" completing-read)))
 
 (defcustom dumb-jump-ivy-jump-to-selected-function
   #'dumb-jump-ivy-jump-to-selected
@@ -1880,8 +1880,8 @@ This is the persistent action (\\[helm-execute-persistent-action]) for helm."
 for user to select.  Filters PROJ path from files for display."
   (let ((choices (--map (dumb-jump--format-result proj it) results)))
     (cond
-	 ((eq dumb-jump-selector 'completing-read)
-	  (dumb-jump-to-selected results choices (completing-read "Jump to: " choices)))
+     ((eq dumb-jump-selector 'completing-read)
+      (dumb-jump-to-selected results choices (completing-read "Jump to: " choices)))
      ((and (eq dumb-jump-selector 'ivy) (fboundp 'ivy-read))
       (funcall dumb-jump-ivy-jump-to-selected-function results choices proj))
      ((and (eq dumb-jump-selector 'helm) (fboundp 'helm))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -65,7 +65,8 @@
   :group 'dumb-jump
   :type '(choice (const :tag "Popup" popup)
                  (const :tag "Helm" helm)
-                 (const :tag "Ivy" ivy)))
+                 (const :tag "Ivy" ivy)
+				 (const :tag "Completing Read" completing-read)))
 
 (defcustom dumb-jump-ivy-jump-to-selected-function
   #'dumb-jump-ivy-jump-to-selected
@@ -1879,6 +1880,8 @@ This is the persistent action (\\[helm-execute-persistent-action]) for helm."
 for user to select.  Filters PROJ path from files for display."
   (let ((choices (--map (dumb-jump--format-result proj it) results)))
     (cond
+	 ((eq dumb-jump-selector 'completing-read)
+	  (dumb-jump-to-selected results choices (completing-read "Jump to: " choices)))
      ((and (eq dumb-jump-selector 'ivy) (fboundp 'ivy-read))
       (funcall dumb-jump-ivy-jump-to-selected-function results choices proj))
      ((and (eq dumb-jump-selector 'helm) (fboundp 'helm))


### PR DESCRIPTION
Currently `dumb-jump-selector` offers three non-standard ways to choose where to jump, even though Emacs has `completing-read` built in. Personally, I think it is preferable to use `completing-read`, because they set `completing-read-function` and changing your completion engine more seamlessly integrates into Emacs as a whole.

A few more notes:
- I still left `'popup` as the default, although I would recommend changing it too.
- Ivy is sort of depreciated, since the "new" completing-read implementation is quasi identical to what Ivy was doing. Therefore, the Ivy option could be depreciated. If there is any interest in this, I could either add the changes to this pull request, or open another one.