### PR TITLE
Failing tests for php

### DIFF
--- a/test/data/proj4-php/User.php
+++ b/test/data/proj4-php/User.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * dumb-jump unit test class
+ *
+ * @property       string $firstname
+ * @property-read  string $lastname
+ * @property       int    $age
+ * @property-write User   $sibling
+ *
+ * @method void calculateAge($date)
+ */
+class User
+{
+    /**
+     * @var string
+     */
+    public $username;
+
+    public static function create($foo)
+    {
+        $create = true;//variable with same name as method
+    }
+
+    protected function saveInternal()
+    {
+        self::create('foo')->getSelf()->calculateAge();
+    }
+
+    public function getSelf()
+    {
+        $getSelf = false;//dummy variable
+        return $this;
+    }
+}
+?>

--- a/test/data/proj4-php/buffer.php
+++ b/test/data/proj4-php/buffer.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Buffer used for testing
+ */
+//static method
+User::create();
+
+//normal method
+$user->getSelf();
+
+//normal method, nested
+$user->getSelf()->saveInternal();
+
+?>

--- a/test/data/proj4-php/functions.php
+++ b/test/data/proj4-php/functions.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Some plain functions
+ */
+function loadDb($dsn) {
+}
+?>

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -12,6 +12,7 @@
 
 (setq test-data-dir (f-expand "./test/data"))
 (setq test-data-dir-elisp (f-join test-data-dir "proj2-elisp"))
+(setq test-data-dir-php (f-join test-data-dir "proj4-php"))
 (setq test-data-dir-proj1 (f-join test-data-dir "proj1"))
 (setq test-data-dir-proj3 (f-join test-data-dir "proj3-clj"))
 (setq test-data-dir-multiproj (f-join test-data-dir "multiproj"))
@@ -1359,5 +1360,27 @@
   (with-mock
    (mock (shell-command-to-string "git grep --full-name -F -c symbol path") => "fileA:1\nfileB:2\n")
    (should (string= (dumb-jump-get-git-grep-files-matching-symbol-as-ag-arg "symbol" "path") "'(path/fileA|path/fileB)'"))))
+
+(ert-deftest dumb-jump-php-method-static ()
+  (let ((buffer-file (f-join test-data-dir-php "buffer.php"))
+        (target-file (f-join test-data-dir-php "User.php")))
+    (with-current-buffer (find-file-noselect buffer-file t)
+      (goto-char (point-min))
+      (forward-line 5)
+      (forward-char 8);;User::cr_eate()
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 19 27))
+       (should (string= target-file (dumb-jump-go)))))))
+
+(ert-deftest dumb-jump-php-method-normal ()
+  (let ((buffer-file (f-join test-data-dir-php "buffer.php"))
+        (target-file (f-join test-data-dir-php "User.php")))
+    (with-current-buffer (find-file-noselect buffer-file t)
+      (goto-char (point-min))
+      (forward-line 8)
+      (forward-char 10);;$user->get_Self()
+      (with-mock
+       (mock (dumb-jump-goto-file-line * 29 20))
+       (should (string= target-file (dumb-jump-go)))))))
 
 ;;;


### PR DESCRIPTION
"dumb-jump-php-method-static" works locally, but not in docker (no idea why, sorry)

"dumb-jump-php-method-normal" searches for "$user->getSelf", but the symbol should be "getSelf" only. I do not know why it does not search for "getSelf" here.