### PR TITLE
Mark legacy commands as obsolete

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2906,6 +2906,25 @@ Using ag to search only the files found via git-grep literal symbol search."
 
 ;;; Xref Backend
 (when (featurep 'xref)
+  (dolist (obsolete
+	   '(dumb-jump-mode
+	     dumb-jump-go
+	     dumb-jump-go-prefer-external-other-window
+	     dumb-jump-go-prompt
+	     dumb-jump-quick-look
+	     dumb-jump-go-other-window
+	     dumb-jump-go-current-window
+	     dumb-jump-go-prefer-external
+	     dumb-jump-go-current-window))
+    (make-obsolete
+     obsolete
+     (format "`%s' has been obsoleted by the xref interface."
+	     obsolete)
+     "2020-06-26"))
+  (make-obsolete 'dumb-jump-back
+		 "`dumb-jump-back' has been obsoleted by `xref-pop-marker-stack'."
+		 "2020-06-26")
+
   (cl-defmethod xref-backend-identifier-at-point ((_backend (eql dumb-jump)))
     (let* ((ident (dumb-jump-get-point-symbol))
 	   (start (car (bounds-of-thing-at-point 'symbol)))


### PR DESCRIPTION
Something along these lines was originally implemented in #343, but I decided to leave it out since it's a different issue.

Marking the commands as obsolete doesn't break anything, so backwards compatibility is ensured. Furthermore, this will only take effect if xref is installed, so the theoretical Emacs 24.1 user won't be annoyed ^^.

---

If you're not interested in obsoleting the old commands, _please_ feel free to say so. If that's the case, I continue developing the changes from #334 into it's own fork, since it has basically been rewritten 100%, dropping all backwards compatibility so that it may be merged into ELPA.