### PR TITLE
Add support for TCL and fix some bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ There is currently basic support for the following languages:
 * SQL
 * Swift
 * SystemVerilog
+* Tcl
 * TypeScript
 * Vala
 * VHDL

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2886,7 +2886,7 @@ Using ag to search only the files found via git-grep literal symbol search."
                       (when (not (s-blank? dumb-jump-git-grep-search-args))
                         (concat " " dumb-jump-git-grep-search-args))
                       " -E"))
-         (fileexps (s-join " " (--map (shell-quote-argument (format "%s/*.%s" proj it)) ggtypes)))
+         (fileexps (s-join " " (or (--map (shell-quote-argument (format "%s/*.%s" proj it)) ggtypes) '(":/"))))
          (exclude-args (s-join " "
                                (--map (shell-quote-argument (concat ":(exclude)" it))
                                       exclude-paths)))

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -773,6 +773,19 @@ or most optimal searcher."
            :regex "JJJ\\s*=\\s*"
            :tests ("$test = 1234"))
 
+    ;; Tcl
+    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "tcl"
+           :regex "proc\\s+JJJ\\s*\\{"
+           :tests ("proc test{" "proc test {"))
+
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "tcl"
+           :regex "set\\s+JJJ"
+           :tests ("set test 1234"))
+
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "tcl"
+           :regex "(variable|global)\\s+JJJ"
+           :tests ("variable test" "global test"))
+
     ;; shell
     (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "shell"
            :regex "function\\s*JJJ\\s*"
@@ -1634,6 +1647,9 @@ or most optimal searcher."
     (:language "javascript" :type "variable" :right "^;" :left nil)
     (:language "typescript" :type "function" :right "^(" :left nil)
     (:language "perl" :type "function" :right "^(" :left nil)
+    (:language "tcl" :type "function" :left "\\[$" :right nil)
+    (:language "tcl" :type "function" :left "^\s*$" :right nil)
+    (:language "tcl" :type "variable" :left "\\$$" :right nil)
     (:language "php" :type "function" :right "^(" :left nil)
     (:language "php" :type "class" :right nil :left "new\s+")
     (:language "elisp" :type "function" :right nil :left "($")
@@ -2273,6 +2289,7 @@ current file."
     (:comment "//" :language "go")
     (:comment "//" :language "zig")
     (:comment "#" :language "perl")
+    (:comment "#" :language "tcl")
     (:comment "//" :language "php")
     (:comment "#" :language "python")
     (:comment "%" :language "matlab")

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -424,14 +424,14 @@
 (ert-deftest dumb-jump-context-point-test ()
   (let* ((sentence "mainWindow.loadUrl('file://')")
          (func "loadUrl")
-         (ctx (dumb-jump-get-point-context sentence func 15)))
+         (ctx (dumb-jump-get-point-context sentence func 11)))
          (should (string= (plist-get ctx :left) "mainWindow."))
          (should (string= (plist-get ctx :right) "('file://')"))))
 
 (ert-deftest dumb-jump-context-point-type-test ()
   (let* ((sentence "mainWindow.loadUrl('file://' + __dirname + '/dt/inspector.html?electron=true');")
          (func "loadUrl")
-         (pt-ctx (dumb-jump-get-point-context sentence func 14))
+         (pt-ctx (dumb-jump-get-point-context sentence func 11))
          (ctx-type (dumb-jump-get-ctx-type-by-language "javascript" pt-ctx)))
     (should (string= ctx-type "function"))))
 
@@ -916,12 +916,6 @@
     (with-mock
      (mock (dumb-jump-goto-file-line "/usr/blah/test2.txt" 52 1))
      (dumb-jump--result-follow data nil "/usr/blah"))))
-
-(ert-deftest dumb-jump-find-start-pos-test ()
-  (let ((cur-pos 9)
-        (line "event event")
-        (word "event"))
-    (should (= (dumb-jump-find-start-pos line word cur-pos) 6))))
 
 (ert-deftest dumb-jump-go-include-lib-test ()
   (let ((el-file (f-join test-data-dir-elisp "fake2.el"))


### PR DESCRIPTION
This PR adds support for TCL and fixes some bugs I found along the way. I can split it into multiple PR's if needed, but my TCL code does not work without the bug fixes here.
### bugs: 
- getting the `:left` and `:right` of a symbol does not work correctly when the symbol is at the start of the line.
You can see this with 
```lisp
(dumb-jump-get-point-context "foo bar baz" "foo" 0) => (:left "f" :right "bar baz")
```
notice that the left side is "f", which is not correct. I also took the chance to simplify the code and update the tests.

- Git grep does not work if not file extensions are specified 

Currently if no file extensions are specified then git grep will not be given a path and will therefore only search from the current directory instead of the root. So in that case we add the magic path `:/` to search from the project root. Note that this only works in Git versions greater then 1.7.6.
