### PR TITLE
Fix C++ function rule with colon in parameter list

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -371,8 +371,8 @@ or most optimal searcher."
 
     ;; c++
     (:type "function" :supports ("ag" "rg" "git-grep") :language "c++"
-           :regex "\\bJJJ(\\s|\\))*\\((\\w|[,&*.<>]|\\s)*(\\))\\s*(const|->|\\{|$)|typedef\\s+(\\w|[(*]|\\s)+JJJ(\\)|\\s)*\\("
-           :tests ("int test(){" "my_struct (*test)(int a, int b){" "auto MyClass::test ( Builder& reference, ) -> decltype( builder.func() ) {" "int test( int *random_argument) const {" "test::test() {" "typedef int (*test)(int);")
+           :regex "\\bJJJ(\\s|\\))*\\((\\w|[,&*.<>:]|\\s)*(\\))\\s*(const|->|\\{|$)|typedef\\s+(\\w|[(*]|\\s)+JJJ(\\)|\\s)*\\("
+           :tests ("int test(){" "my_struct (*test)(int a, int b){" "auto MyClass::test ( Builder::Builder& reference, ) -> decltype( builder.func() ) {" "int test( int *random_argument) const {" "test::test() {" "typedef int (*test)(int);")
            :not ("return test();)" "int test(a, b);" "if( test() ) {" "else test();"))
 
     ;; (:type "variable" :supports ("grep") :language "c++"


### PR DESCRIPTION
A C++ function definition like

```c++
void MyClass::test(std::string) {}
```

is not found by dumb-jump. Fix this by allowing colon in parameter lists.

By the way, many thanks for dumb-jump!