### PR TITLE
Always expand relative paths in xref backend

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2668,16 +2668,10 @@ searcher symbol."
       nil)
      ((and parts line-num-raw)
       (if (= (length parts) 2)
-          (list (let ((path (expand-file-name (nth 0 parts))))
-                  (if (file-name-absolute-p (nth 0 parts))
-                      path
-                    (file-relative-name path)))
+          (list (expand-file-name (nth 0 parts))
                 (nth 1 line-num-raw) (nth 1 parts))
                                         ; this case is when they are searching a particular file...
-        (list (let ((path (expand-file-name cur-file)))
-                (if (file-name-absolute-p cur-file)
-                    path
-                  (file-relative-name path)))
+        (list (expand-file-name cur-file)
               (nth 1 line-num-raw) (nth 0 parts)))))))
 
 (defun dumb-jump-parse-response-lines (parsed cur-file cur-line-num)

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2668,10 +2668,16 @@ searcher symbol."
       nil)
      ((and parts line-num-raw)
       (if (= (length parts) 2)
-          (list (expand-file-name (nth 0 parts))
+          (list (let ((path (expand-file-name (nth 0 parts))))
+                  (if (file-name-absolute-p (nth 0 parts))
+                      path
+                    (file-relative-name path)))
                 (nth 1 line-num-raw) (nth 1 parts))
                                         ; this case is when they are searching a particular file...
-        (list (expand-file-name cur-file)
+        (list (let ((path (expand-file-name cur-file)))
+                (if (file-name-absolute-p cur-file)
+                    path
+                  (file-relative-name path)))
               (nth 1 line-num-raw) (nth 0 parts)))))))
 
 (defun dumb-jump-parse-response-lines (parsed cur-file cur-line-num)
@@ -3047,7 +3053,7 @@ Using ag to search only the files found via git-grep literal symbol search."
                          (xref-make
                           (plist-get res :context)
                           (xref-make-file-location
-                           (plist-get res :path)
+                           (expand-file-name (plist-get res :path))
                            (plist-get res :line)
                            0)))
                        (if do-var-jump


### PR DESCRIPTION
I also ran into issue #333 when using `git grep` and the `xref` backend. The problem is when you select a result with a relative path from the `*xref*` buffer the file name is expanded relative to the `default-directory` in the `*xref*` buffer which may be different to the `default-directory` of the current file, which the `git grep` results are relative to. The `*xref*` buffer is reused between searches and its `default-directory` is never updated, so you typically hit this bug by doing a search from one file, which works, and then doing another search from a second file in a different directory.

Simple fix here which works for me is to always expand the search results to absolute path names.