### PR TITLE
Don't raise an error when no symbol is found at a point

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -3006,11 +3006,13 @@ Using ag to search only the files found via git-grep literal symbol search."
                  "2020-06-26")
 
   (cl-defmethod xref-backend-identifier-at-point ((_backend (eql dumb-jump)))
-    (let ((start (dumb-jump--get-symbol-start)))
-      (and start (let* ((ident (dumb-jump-get-point-symbol))
-                        (line (dumb-jump-get-point-line))
-                        (ctx (dumb-jump-get-point-context line ident start)))
-                   (propertize ident :dumb-jump-ctx ctx)))))
+    (let ((bounds (bounds-of-thing-at-point 'symbol)))
+      (and bounds (let* ((ident (dumb-jump-get-point-symbol))
+			             (start (car bounds))
+			             (col (- start (point-at-bol)))
+			             (line (dumb-jump-get-point-line))
+			             (ctx (dumb-jump-get-point-context line ident col)))
+		            (propertize ident :dumb-jump-ctx ctx)))))
 
   (cl-defmethod xref-backend-definitions ((_backend (eql dumb-jump)) prompt)
     (let* ((info (dumb-jump-get-results prompt))
@@ -3061,7 +3063,10 @@ Using ag to search only the files found via git-grep literal symbol search."
                          match-cur-file-front))))))
 
   (cl-defmethod xref-backend-apropos ((_backend (eql dumb-jump)) pattern)
-    (xref-backend-definitions 'dumb-jump pattern)))
+    (xref-backend-definitions 'dumb-jump pattern))
+
+  (cl-defmethod xref-backend-identifier-completion-table ((_backend (eql dumb-jump)))
+    nil))
 
 ;;;###autoload
 (defun dumb-jump-xref-activate ()


### PR DESCRIPTION
- Current behavior: when `M-.` is pressed, an error occurs if there is no symbol at a point
- Expected behavior: a prompt will open, asking for an identifier

Originally this problem was fixed with the PR #357, but a regression has been introduced later with the PR #366. In addition to reverting the change in `xref-backend-identifier-at-point`, defining `xref-backend-identifier-completion-table` was required to fix all the errors, hence the diff in the commit.

### Notes on the definition of xref-backend-identifier-completion-table
Personally I define `xref-backend-identifier-completion-table` as follows (slightly modified from [this code](https://github.com/NicolasPetton/xref-js2/blob/6f1ed5dae0c2485416196a51f2fa92f32e4b8262/xref-js2.el#L125)):

```elisp
(cl-defmethod xref-backend-identifier-completion-table ((_backend (eql dumb-jump)))
  (let (words)
    (save-excursion
      (save-restriction
        (widen)
        (goto-char (point-min))
        (while (re-search-forward "[a-zA-Z_][0-9a-zA-Z_]*" nil t)
          (add-to-list 'words (match-string-no-properties 0)))
        (seq-uniq words)))))
```

This assumes that identifiers match the regular expression `[a-zA-Z_][0-9a-zA-Z_]*`, which is the case in programming languages I deal with frequently. However since in some programming languages (most notably those languages falling in the Lisp family) `-` (hyphen) can also be used in an identifier and I thought it would be inappropriate to limit the scope to a fraction of the languages this library supports, I defined it to always return `nil` in this PR.