### PR TITLE
Allow silencing warnings about the legacy interface

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1705,6 +1705,11 @@ inaccurate jump).  If nil, jump without confirmation but print a warning."
   :group 'dumb-jump
   :type 'boolean)
 
+(defcustom dumb-jump-disable-obsolete-warnings nil
+  "If non-nil, don't warn about using the legacy interface."
+  :group 'dumb-jump
+  :type 'boolean)
+
 (defun dumb-jump-message-prin1 (str &rest args)
   "Helper function when debugging apply STR 'prin1-to-string' to all ARGS."
   (apply 'message str (-map 'prin1-to-string args)))
@@ -2980,24 +2985,25 @@ Using ag to search only the files found via git-grep literal symbol search."
 
 ;;; Xref Backend
 (when (featurep 'xref)
-  (dolist (obsolete
-           '(dumb-jump-mode
-             dumb-jump-go
-             dumb-jump-go-prefer-external-other-window
-             dumb-jump-go-prompt
-             dumb-jump-quick-look
-             dumb-jump-go-other-window
-             dumb-jump-go-current-window
-             dumb-jump-go-prefer-external
-             dumb-jump-go-current-window))
-    (make-obsolete
-     obsolete
-     (format "`%s' has been obsoleted by the xref interface."
-             obsolete)
-     "2020-06-26"))
-  (make-obsolete 'dumb-jump-back
-                 "`dumb-jump-back' has been obsoleted by `xref-pop-marker-stack'."
-                 "2020-06-26")
+  (unless dumb-jump-disable-obsolete-warnings
+    (dolist (obsolete
+             '(dumb-jump-mode
+               dumb-jump-go
+               dumb-jump-go-prefer-external-other-window
+               dumb-jump-go-prompt
+               dumb-jump-quick-look
+               dumb-jump-go-other-window
+               dumb-jump-go-current-window
+               dumb-jump-go-prefer-external
+               dumb-jump-go-current-window))
+      (make-obsolete
+       obsolete
+       (format "`%s' has been obsoleted by the xref interface."
+               obsolete)
+       "2020-06-26"))
+    (make-obsolete 'dumb-jump-back
+                   "`dumb-jump-back' has been obsoleted by `xref-pop-marker-stack'."
+                   "2020-06-26"))
 
   (cl-defmethod xref-backend-identifier-at-point ((_backend (eql dumb-jump)))
     (let ((bounds (bounds-of-thing-at-point 'symbol)))


### PR DESCRIPTION
This patch would implement something as suggested in #380. It would probably make sense to add it, if we don't plan to remove the legacy interface.