### PR TITLE
fix look-for splitting for Fennel

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2110,7 +2110,7 @@ to keep looking for another root."
    ((and (string= lang "clojure") (s-contains? "/" look-for))
     (nth 1 (s-split "/" look-for)))
    ((and (string= lang "fennel") (s-contains? "." look-for))
-    (-last-item (s-split "." look-for)))
+    (-last-item (s-split "\\." look-for)))
    ((and (string= lang "ruby") (s-contains? "::" look-for))
     (-last-item (s-split "::" look-for)))
    ((and (or (string= lang "ruby") (string= lang "crystal")) (s-starts-with? ":" look-for))


### PR DESCRIPTION
Sorry, totally forgot that `s-split` expets a regular expression here.