### PR TITLE
Add initial support for Apex, the language for Salesforce servers

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1492,7 +1492,23 @@ or most optimal searcher."
 
     (:type "enum" :supports ("ag" "grep" "rg" "git-grep") :language "protobuf"
            :regex "enum\\s+JJJ\\s*\\\{"
-           :tests ("enum test{" "enum test {")))
+           :tests ("enum test{" "enum test {"))
+
+    ;; apex (literally the same regexes as java)
+    (:type "function" :supports ("ag" "rg") :language "apex"
+           :regex "^\\s*(?:[\\w\\[\\]]+\\s+){1,3}JJJ\\s*\\\("
+           :tests ("int test()" "int test(param)" "static int test()" "static int test(param)"
+                   "public static MyType test()" "private virtual SomeType test(param)" "static int test()"
+                   "private foo[] test()")
+           :not ("test()" "testnot()" "blah = new test()" "foo bar = test()"))
+
+    (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "apex"
+           :regex "\\s*\\bJJJ\\s*=[^=\\n)]+" :tests ("int test = 1234") :not ("if test == 1234:" "int nottest = 44"))
+
+    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "apex"
+           :regex "(class|interface)\\s*JJJ\\b"
+           :tests ("class test:" "public class test implements Something")
+           :not ("class testnot:" "public class testnot implements Something")))
 
 
   "List of regex patttern templates organized by language and type to use for generating the grep command."
@@ -1646,7 +1662,9 @@ or most optimal searcher."
     (:language "kotlin" :ext "kts" :agtype "kotlin" :rgtype "kotlin")
     (:language "protobuf" :ext "proto" :agtype "proto" :rgtype "protobuf")
     (:language "hcl" :ext "tf" :agtype "terraform" :rgtype "tf")
-    (:language "hcl" :ext "tfvars" :agtype "terraform" :rgtype nil))
+    (:language "hcl" :ext "tfvars" :agtype "terraform" :rgtype nil)
+    (:language "apex" :ext "cls" :agtype nil :rgtype nil)
+    (:language "apex" :ext "trigger" :agtype nil :rgtype nil))
 
   "Mapping of programming language(s) to file extensions."
   :group 'dumb-jump
@@ -2324,7 +2342,8 @@ current file."
     (:comment "//" :language "scss")
     (:comment "//" :language "pascal")
     (:comment "//" :language "protobuf")
-    (:comment "#" :language "hcl"))
+    (:comment "#" :language "hcl")
+    (:comment "//" :language "apex"))
   "List of one-line comments organized by language."
   :group 'dumb-jump
   :type


### PR DESCRIPTION
Apex is a strongly typed, object-oriented programming language, using
syntax that looks like Java and acts like database stored procedures.

https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_dev_guide.htm