### PR TITLE
Call helm-make-source directly

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2019,7 +2019,7 @@ for user to select.  Filters PROJ path from files for display."
       (funcall dumb-jump-ivy-jump-to-selected-function results choices proj))
      ((and (eq dumb-jump-selector 'helm) (fboundp 'helm))
       (helm :sources
-            (helm-build-sync-source "Jump to: "
+            (helm-make-source "Jump to: " 'helm-source-sync
                                     :action '(("Jump to match" . dumb-jump-result-follow))
                                     :candidates (-zip choices results)
                                     :persistent-action 'dumb-jump-helm-persist-action)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -448,7 +448,7 @@
          (results '((:path "/usr/blah/test.txt" :line 54 :context "function thing()")
                     (:path "/usr/blah/test2.txt" :line 52 :context "var thing = function()" :target "a"))))
     (with-mock
-     (mock (helm-build-sync-source * :action * :candidates * :persistent-action *))
+     (mock (helm-make-source "Jump to: " 'helm-source-sync :action * :candidates * :persistent-action *))
      (mock (helm * * :buffer "*helm dumb jump choices*"))
      (dumb-jump-prompt-user-for-choice "/usr/blah" results))))
 


### PR DESCRIPTION
Avoids macro expansion issues if Helm is not yet loaded.

Fixes issue in environment like NixOS. Fixes https://github.com/jacktasia/dumb-jump/issues/224