### PR TITLE
Drop the "s" dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,4 +7,5 @@
  (depends-on "el-mock")
  (depends-on "noflet")
  (depends-on "ert-runner")
- (depends-on "undercover"))
+ (depends-on "undercover")
+ (depends-on "compat"))


### PR DESCRIPTION
Hi,

this patch would remove s, replacing it with the [compat](https://elpa.gnu.org/packages/compat.html) package.  This change would allow for dumb-jump to be added to NonGNU ELPA, as mentioned in #399.