### PR TITLE
Use cl-lib version instead of cl.el

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2891,7 +2891,7 @@ searcher symbol."
   "Search for the literal SYMBOL in the PROJ-ROOT via git grep for a list of file matches."
   (let* ((cmd (format "git grep --full-name -F -c %s %s" (shell-quote-argument symbol) proj-root))
          (result (s-trim (shell-command-to-string cmd)))
-         (matched-files (--map (first (s-split ":" it))
+         (matched-files (--map (cl-first (s-split ":" it))
                                (s-split "\n" result))))
     matched-files))
 


### PR DESCRIPTION
cl.el is deprecated. This also fixes the following byte-compile warning.

```
dumb-jump.el:2894:33: Warning: the function ‘first’ is not known to be
    defined.
```