### PR TITLE
ci: Add Emacs 28.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - '26.2'
           - '26.3'
           - '27.1'
+          - '28.1'
           - 'snapshot'
         cask_version:
           - 'snapshot'


### PR DESCRIPTION
Emacs 28.1 is now the latest stable release.