### PR TITLE
Add generic rule for matching all clojure def types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1.1.1
         with:
-          python-version: '3.7.17'
+          python-version: '3.7'
           architecture: 'x64'
       - uses: purcell/setup-emacs@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1.1.1
         with:
-          python-version: '3.7.16'
+          python-version: '3.7.17'
           architecture: 'x64'
       - uses: purcell/setup-emacs@master
         with:

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -418,45 +418,20 @@ or most optimal searcher."
 
     ;; clojure
     (:type "variable" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(def\\s+JJJ\\j"
-           :tests ("(def test (foo)"))
-
-    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(defn-?\\s+JJJ\\j"
-           :tests ("(defn test [foo]" "(defn- test [foo]")
-           :not ("(defn test? [foo]" "(defn- test? [foo]"))
-
-    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(defmacro\\s+JJJ\\j"
-           :tests ("(defmacro test [foo]"))
-
-    (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(deftask\\s+JJJ\\j"
-           :tests ("(deftask test [foo]"))
-
-    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(deftype\\s+JJJ\\j"
-           :tests ("(deftype test [foo]"))
-
-    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(defmulti\\s+JJJ\\j"
-           :tests ("(defmulti test fn"))
-
-    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(defmethod\\s+JJJ\\j"
-           :tests ("(defmethod test type"))
-
-    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(definterface\\s+JJJ\\j"
-           :tests ("(definterface test (foo)"))
-
-    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(defprotocol\\s+JJJ\\j"
-           :tests ("(defprotocol test (foo)"))
-
-    (:type "type" :supports ("ag" "grep" "rg" "git-grep") :language "clojure"
-           :regex "\\(defrecord\\s+JJJ\\j"
-           :tests ("(defrecord test [foo]"))
+           :regex "\\(def.*\ JJJ\\j"
+           :tests ("(def test (foo)"
+                   "(defn test [foo]"
+                   "(defn ^:some-data test [foo]"
+                   "(defn- test [foo]"
+                   "(defmacro test [foo]"
+                   "(deftask test [foo]"
+                   "(deftype test [foo]"
+                   "(defmulti test fn"
+                   "(defmethod test type"
+                   "(definterface test (foo)"
+                   "(defprotocol test (foo)"
+                   "(defrecord test [foo]"
+                   "(deftest test"))
 
     ;; coffeescript
     (:type "function" :supports ("ag" "grep" "rg" "git-grep") :language "coffeescript"


### PR DESCRIPTION
+ Fixes #438 
+ Existing rules didn't have support for `deftest` or a function with metadata.
+ Example - (defn ^:some-data say-hello [] (println "hello"))

Above function wouldn't be matched even if it is defined using `defn`.

+ Since we are only using one regex instead of multiple, it has become faster as well.

Test:
- Added new testcases