### PR TITLE
Use project.el to locate project roots

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2052,6 +2052,9 @@ for user to select.  Filters PROJ path from files for display."
    (expand-file-name
     (or
      dumb-jump-project
+     (when-let (((fboundp 'project-current))
+                (proj (project-current t (file-name-directory filepath))))
+       (project-root proj))
      (locate-dominating-file filepath #'dumb-jump-get-config)
      dumb-jump-default-project))))
 


### PR DESCRIPTION
[`project.el`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Projects.html) received a revamp in Emacs 28 and has pretty much become the standard Emacs way to locate project roots. In particular, it detects VC projects out of the box, obsoleting `dumb-jump-project-denoters`.

For older versions of emacs without `project-current`, this PR falls back to `dumb-jump-project-denoters` and `dumb-jump-default-project`. However, `dumb-jump-project`, still takes precedence if set.