### PR TITLE
Fix warning about deprecated -zip

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2963,7 +2963,7 @@ This is the persistent action (\\[helm-execute-persistent-action]) for helm."
   "Offer CHOICES as candidates through `ivy-read'.
 Then execute dumb-jump-result-follow' on the selected choice RESULTS.
 Ignore _PROJ."
-  (ivy-read "Jump to: " (-zip choices results)
+  (ivy-read "Jump to: " (-zip-pair choices results)
             :action (lambda (cand)
                       (dumb-jump-result-follow (cdr cand)))
             :caller 'dumb-jump-ivy-jump-to-selected))


### PR DESCRIPTION
* Replaced use of `-zip` by `-zip-pair` in `dumb-jump-ivy-jump-to-selected`,
  as the code needs to produce a list of 2 members cons cells.  `-zip` still
  does that but that behaviour is deprecated; the `-zip-pair` should be used
  now.

  The [dash.el manual -zip description](https://github.com/magnars/dash.el?tab=readme-ov-file#-zip-rest-lists)
  warns about using `-zip` and recommends using `-zip-pair` to build list of
  cons cells from 2 lists.

* This shows 2 other commits, the second undoing the first, as I unfortunately commit the first in the master branch instead of the dedicated branch.  The only code pushed by this is for the warning fix.

Note that once all my pending PRs are integrated there should be no byte-compiler warnings left. 