### PR TITLE
python: add support for definitions with type annotations

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1041,11 +1041,24 @@ If nil add also the language type of current src block."
 
     ;;-- python
     (:language "python" :type "variable"
-           :supports ("ag" "grep" "rg" "git-grep")
+           :supports ("ag" "rg")
            :regex "\\s*\\bJJJ\\b(\\s*:[^=\\n]+)?\\s*=[^=\\n]+"
            :tests ("test = 1234"
                    "test: int = 1234"
                    "test: int | None = 1234"
+                   "test: List[Optional[int]] = [1234, None]")
+           :not ("if test == 1234:"
+                 "_test = 1234"
+                 "if (test := 3):"
+                 "while test:"
+                 "test['key'] = 1234"))
+
+        (:language "python" :type "variable"
+           :supports ("grep" "git-grep")
+           :regex "\\s*\\bJJJ\\b(\\s*:[^=]+)?\\s*=[^=]+"
+           :tests ("test = 1234"
+                   "test: int = 1234"
+                   "test: int | None = 12i34"
                    "test: List[Optional[int]] = [1234, None]")
            :not ("if test == 1234:"
                  "_test = 1234"


### PR DESCRIPTION
Jumping to the definition `my_sql_table` is not working when `my_sql_table` is defined as

```
my_sql_table: Table = Table(
```

I figured out that this is because the regexp for matching python variable definitions does not match definitions with type annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Python variable detection to recognize annotated declarations (simple and nested annotations) and a wider range of assignment forms.

* **Bug Fixes**
  * Improved pattern handling to reduce incorrect matches in variable lookups and assignment-like contexts, including walrus-style and control-flow cases.

* **Tests**
  * Expanded test coverage to include annotated variables and additional assignment/walrus-like scenarios to validate the improved detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->