### PR TITLE
Add org-mode support for named blocks, call refs, headings, and custom IDs

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -1061,6 +1061,61 @@ If nil add also the language type of current src block."
                  "Nottest = 1234;"
                  "AtestNot = 1234;"))
 
+    ;;-- org
+    ;; org named blocks
+    (:language "org" :type "function"
+           :supports ("ag" "grep" "rg" "git-grep")
+           :regex "^\\s*#\\+[nN][aA][mM][eE]:\\s*JJJ\\j"
+           :tests ("#+name: test"
+                   "#+NAME: test"
+                   "#+Name: test"
+                   "  #+name: test"
+                   "#+name:test")
+           :not ("#+name: tester"
+                 "#+name: test-block"
+                 "some #+name: test"))
+
+    ;; org call references (#+call: block-name)
+    (:language "org" :type "function"
+           :supports ("ag" "grep" "rg" "git-grep")
+           :regex "^\\s*#\\+[cC][aA][lL][lL]:\\s*JJJ\\j"
+           :tests ("#+call: test"
+                   "#+CALL: test"
+                   "#+Call: test"
+                   "  #+call: test"
+                   "#+call: test()"
+                   "#+call: test(x=1)")
+           :not ("#+call: tester"
+                 "#+call: test-other"
+                 "some #+call: test"))
+
+    ;; org headings (* Heading text)
+    (:language "org" :type "type"
+           :supports ("ag" "grep" "rg" "git-grep")
+           :regex "^\\*+\\s+JJJ\\j"
+           :tests ("* test"
+                   "** test"
+                   "*** test"
+                   "**** test"
+                   "* test heading"
+                   "** test with more words")
+           :not ("* tester"
+                 "** testing"
+                 "* test-other"
+                 "not a * test heading"))
+
+    ;; org custom ID (:CUSTOM_ID: value in property drawers)
+    (:language "org" :type "type"
+           :supports ("ag" "grep" "rg" "git-grep")
+           :regex "^\\s*:CUSTOM_ID:\\s*JJJ\\j"
+           :tests (":CUSTOM_ID: test"
+                   ":CUSTOM_ID:  test"
+                   "  :CUSTOM_ID: test"
+                   ":CUSTOM_ID:test")
+           :not (":CUSTOM_ID: tester"
+                 ":CUSTOM_ID: test-other"
+                 "inline :CUSTOM_ID: test text"))
+
     ;;-- ruby
     (:language "ruby" :type "variable"
            :supports ("ag" "rg" "git-grep")

--- a/test/data/proj1/src/org/named-blocks.org
+++ b/test/data/proj1/src/org/named-blocks.org
@@ -1,0 +1,88 @@
+* Named Block Tests
+:PROPERTIES:
+:CUSTOM_ID: named-block-tests
+:END:
+
+This file tests dumb-jump's ability to find org constructs.
+
+** Named Blocks Section
+
+Reference to myblock: <<myblock>>
+
+#+name: myblock
+#+begin_src python
+def test_function():
+    return 42
+#+end_src
+
+Another reference: <<UPPERCASE>>
+
+#+NAME: UPPERCASE
+#+begin_src elisp
+(message "test")
+#+end_src
+
+Mixed case: <<MixedCase>>
+
+#+Name: MixedCase
+#+begin_src shell
+echo "hello"
+#+end_src
+
+Indented block reference: <<indented>>
+
+  #+name: indented
+  #+begin_src python
+  pass
+  #+end_src
+
+Test for uniqueblock lookup: uniqueblock
+
+#+name: uniqueblock
+#+begin_src elisp
+(message "unique")
+#+end_src
+
+Test for nospace lookup: nospace
+
+#+name:nospace
+#+begin_src elisp
+(message "no space after colon")
+#+end_src
+
+** Call References Section
+:PROPERTIES:
+:CUSTOM_ID: call-section
+:END:
+
+See also the section with ID call-section for more info.
+
+#+call: myblock()
+
+#+CALL: UPPERCASE()
+
+** Headings Section
+
+Reference to MainTopic heading: MainTopic
+
+*** MainTopic
+
+Some content here with MainTopic mentioned again.
+
+*** SubHeading One
+
+Some content here.
+
+*** SubHeading Two
+:PROPERTIES:
+:CUSTOM_ID: subheading-two
+:END:
+
+More content here.
+
+*** NoSpaceID Section
+:PROPERTIES:
+:CUSTOM_ID:nospace-id
+:END:
+
+Reference to nospace-id custom ID: nospace-id

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1242,6 +1242,113 @@
     (if (version< org-version "9")
         (setq dumb-jump-project oldproject))))
 
+(ert-deftest dumb-jump-org-named-block-test ()
+  "Test jumping to org named block definition"
+  (let ((org-file (f-join test-data-dir-proj1 "src" "org" "named-blocks.org"))
+        (oldpar dumb-jump-force-searcher)
+        (old-rg-installed dumb-jump--rg-installed?))
+    (setq dumb-jump-force-searcher 'rg)
+    (setq dumb-jump--rg-installed? 'unset)
+    (with-current-buffer (find-file-noselect org-file t)
+      (goto-char (point-min))
+      (forward-line 38)  ; Line 39: "Test for uniqueblock lookup: uniqueblock"
+      (forward-char 34)  ; Position cursor on "uniqueblock" at end of line
+      (with-mock
+        (stub dumb-jump-rg-installed? => t)
+        (mock (dumb-jump-goto-file-line * 41 8))  ; Line 41 is #+name: uniqueblock (col 8)
+        (should (string= org-file (with-no-warnings (dumb-jump-go))))))
+    (setq dumb-jump-force-searcher oldpar)
+    (setq dumb-jump--rg-installed? old-rg-installed)))
+
+(ert-deftest dumb-jump-org-heading-test ()
+  "Test jumping to org heading"
+  (let ((org-file (f-join test-data-dir-proj1 "src" "org" "named-blocks.org"))
+        (oldpar dumb-jump-force-searcher)
+        (old-rg-installed dumb-jump--rg-installed?))
+    (setq dumb-jump-force-searcher 'rg)
+    (setq dumb-jump--rg-installed? 'unset)
+    (with-current-buffer (find-file-noselect org-file t)
+      (goto-char (point-min))
+      (forward-line 65)  ; Line 66: "Reference to MainTopic heading: MainTopic"
+      (forward-char 35)  ; Position cursor on "MainTopic" at end of line
+      (with-mock
+        (stub dumb-jump-rg-installed? => t)
+        (mock (dumb-jump-goto-file-line * 68 4))  ; Line 68 is *** MainTopic (col 4)
+        (should (string= org-file (with-no-warnings (dumb-jump-go))))))
+    (setq dumb-jump-force-searcher oldpar)
+    (setq dumb-jump--rg-installed? old-rg-installed)))
+
+(ert-deftest dumb-jump-org-custom-id-test ()
+  "Test jumping to org CUSTOM_ID"
+  (let ((org-file (f-join test-data-dir-proj1 "src" "org" "named-blocks.org"))
+        (oldpar dumb-jump-force-searcher)
+        (old-rg-installed dumb-jump--rg-installed?))
+    (setq dumb-jump-force-searcher 'rg)
+    (setq dumb-jump--rg-installed? 'unset)
+    (with-current-buffer (find-file-noselect org-file t)
+      (goto-char (point-min))
+      (forward-line 57)  ; Line 58: "See also the section with ID call-section for more info."
+      (forward-char 34)  ; Position cursor on "call-section"
+      (with-mock
+        (stub dumb-jump-rg-installed? => t)
+        (mock (dumb-jump-goto-file-line * 55 12))  ; Line 55 is :CUSTOM_ID: call-section (col 12)
+        (should (string= org-file (with-no-warnings (dumb-jump-go))))))
+    (setq dumb-jump-force-searcher oldpar)
+    (setq dumb-jump--rg-installed? old-rg-installed)))
+
+(ert-deftest dumb-jump-org-call-test ()
+  "Test jumping from #+call reference to named block definition"
+  (let ((org-file (f-join test-data-dir-proj1 "src" "org" "named-blocks.org"))
+        (oldpar dumb-jump-force-searcher)
+        (old-rg-installed dumb-jump--rg-installed?))
+    (setq dumb-jump-force-searcher 'rg)
+    (setq dumb-jump--rg-installed? 'unset)
+    (with-current-buffer (find-file-noselect org-file t)
+      (goto-char (point-min))
+      (forward-line 61)  ; Line 62: "#+CALL: UPPERCASE()"
+      (forward-char 8)   ; Position cursor on "UPPERCASE"
+      (with-mock
+        (stub dumb-jump-rg-installed? => t)
+        (mock (dumb-jump-goto-file-line * 20 8))  ; Line 20 is #+NAME: UPPERCASE (col 8)
+        (should (string= org-file (with-no-warnings (dumb-jump-go))))))
+    (setq dumb-jump-force-searcher oldpar)
+    (setq dumb-jump--rg-installed? old-rg-installed)))
+
+(ert-deftest dumb-jump-org-named-block-nospace-test ()
+  "Test jumping to org named block definition without space after colon"
+  (let ((org-file (f-join test-data-dir-proj1 "src" "org" "named-blocks.org"))
+        (oldpar dumb-jump-force-searcher)
+        (old-rg-installed dumb-jump--rg-installed?))
+    (setq dumb-jump-force-searcher 'rg)
+    (setq dumb-jump--rg-installed? 'unset)
+    (with-current-buffer (find-file-noselect org-file t)
+      (goto-char (point-min))
+      (forward-line 45)  ; Line 46: "Test for nospace lookup: nospace"
+      (forward-char 28)  ; Position cursor on "nospace" at end of line
+      (with-mock
+        (stub dumb-jump-rg-installed? => t)
+        (mock (dumb-jump-goto-file-line * 48 7))  ; Line 48 is #+name:nospace (col 7)
+        (should (string= org-file (with-no-warnings (dumb-jump-go))))))
+    (setq dumb-jump-force-searcher oldpar)
+    (setq dumb-jump--rg-installed? old-rg-installed)))
+
+(ert-deftest dumb-jump-org-custom-id-nospace-test ()
+  "Test jumping to org CUSTOM_ID without space after colon"
+  (let ((org-file (f-join test-data-dir-proj1 "src" "org" "named-blocks.org"))
+        (oldpar dumb-jump-force-searcher)
+        (old-rg-installed dumb-jump--rg-installed?))
+    (setq dumb-jump-force-searcher 'rg)
+    (setq dumb-jump--rg-installed? 'unset)
+    (with-current-buffer (find-file-noselect org-file t)
+      (goto-char (point-min))
+      (forward-line 87)  ; Line 88: "Reference to nospace-id custom ID: nospace-id"
+      (forward-char 36)  ; Position cursor on "nospace-id" at end of line
+      (with-mock
+        (stub dumb-jump-rg-installed? => t)
+        (mock (dumb-jump-goto-file-line * 85 11))  ; Line 85 is :CUSTOM_ID:nospace-id (col 11)
+        (should (string= org-file (with-no-warnings (dumb-jump-go))))))
+    (setq dumb-jump-force-searcher oldpar)
+    (setq dumb-jump--rg-installed? old-rg-installed)))
 
 
 ;; This test verifies that having ".dumbjumpignore" files in the two sub-projects will make it find


### PR DESCRIPTION
## Summary

Closes #453

Adds dumb-jump support for org-mode native constructs:
- **Named blocks** (`#+name: block-name`) - jump to named src block definitions
- **Call references** (`#+call: block-name`) - jump from call to definition
- **Headings** (`* Heading`, `** Subheading`) - jump to org headings
- **Custom IDs** (`:CUSTOM_ID: id-value`) - jump to property drawer IDs

All patterns are case-insensitive for org keywords (e.g., `#+NAME:`, `#+name:`, `#+Name:` all match).

## Test Plan

- [x] Added 6 new tests covering all 4 constructs
- [x] Tests cover edge cases: no-space-after-colon, case variations
- [x] All tests use `with-mock` pattern consistent with existing org tests
- [x] Verified regex patterns work with ag, grep, rg, git-grep backends

# Related

- Complements PR #411 which added org src block jumping (to embedded language definitions)
- This PR adds jumping to org-native constructs like named blocks and headings
