### PR TITLE
Improve rule regexp testing code. Add support for defconst and defvar-local search for elisp.

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -382,21 +382,26 @@ If nil add also the language type of current src block."
 
     (:language "elisp" :type "variable"
            :supports ("ag" "grep" "rg" "git-grep")
-           :regex "\\(defvar\\b\\s*JJJ\\j"
+           :regex "\\(defvar(-local)?\\b\\s*JJJ\\j"
            :tests ("(defvar test "
-                   "(defvar test\n")
+                   "(defvar test\n"
+                   "(defvar-local test"
+                   "(defvar-local test\n")
            :not ("(defvar tester"
                  "(defvar test?"
-                 "(defvar test-"))
+                 "(defvar test-"
+                 "(defvar-local tester"
+                 "(defvar-local test?"
+                 "(defvar-local test-"))
 
-    ;; (:language "elisp" :type "variable"
-    ;;        :supports ("ag" "grep" "rg" "ugrep" "git-grep")
-    ;;        :regex "\\(defconst\\b\\s*JJJ\\j"
-    ;;        :tests ("(defconst test "
-    ;;                "(defconst test\n")
-    ;;        :not ("(defconst tester"
-    ;;              "(defconst test?"
-    ;;              "(defconst test-"))
+    (:language "elisp" :type "variable"
+           :supports ("ag" "grep" "rg" "ugrep" "git-grep")
+           :regex "\\(defconst\\b\\s*JJJ\\j"
+           :tests ("(defconst test "
+                   "(defconst test\n")
+           :not ("(defconst tester"
+                 "(defconst test?"
+                 "(defconst test-"))
 
     (:language "elisp" :type "variable"
            :supports ("ag" "grep" "rg" "git-grep")


### PR DESCRIPTION
The purpose of the changes is to:
- Simplify maintenance of a set of the rule regexp testing.
- Add ability to jump to `defconst` and `defvar-local` definitions in elisp code. 
- Start updating the regexp when necessary.

The second goal was made simpler by achieving the first one, done by eliminating duplication of adjusted rule regexp strings used in several test functions by the use of one utility function (`dumb-jump--elisp-expected-regexps`) that holds the strings (in the current implementation).  Further improvement is possible: collecting the regexp strings from the rules for a specified language.  I did not do that yet.  I first want to test the support for other languages and the rexexp syntax.

I am also planning to add more tests to increase coverage.  But again, that will come later.

This is done while I'm working on adding the support for ugrep.  That can only be pushed here once I fully understand all the details of regexps and the history (which is what I'm learning by doing this).


 