### PR TITLE
Add .cask, help, test-this targets to make file. Tag targets Phony.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,45 @@
+# Build Control Makefile
+#
+# - Best used with GNU Make.
+# - Support NetBSD bmake (will issue a warning on the -include line; ignore it)
+# - If support for smake (Jörg Schilling make) is needed, a SMakefile should be written.
+
+# Identify tools:
+
+# Set this to detect if GNU Make is being used.
+_GNU_MAKE_ONLY_FILE = $(if $(MAKE_VERSION),gnu.mk)
+
+# Set these but don't override values from the environment if they are set.
 CASK ?= cask
 EMACS ?= emacs
 
+# ----------------------------------------------------------------------------
+# Rules
+# -----
+
+# Most recipes do not correspond to the presence of a file; they must be
+# declared PHONY to avoid conflict with a file name.
+#
+.PHONY: all test unit install test-concurrent test-go docker-build-test-runner \
+        docker-push-test-runner test-all-in-docker test-in-docker setup \
+        actions-test help
+
+
 all: test
+
+.cask:
+	${CASK}
 
 test: unit
 
-unit:
+unit: .cask
 	${CASK} exec ert-runner
 
 install:
 	${CASK} install
 
-test-concurrent:
-	cask
+
+test-concurrent: .cask
 	@go run test/ert_runner.go -p ".*-ag-.*" -p ".*-rg-.*" test/dumb-jump-test.el
 
 test-go:
@@ -34,3 +61,33 @@ setup:
 	@bash test/github-actions-setup.sh
 
 actions-test: install setup unit
+
+# Include the test-some rule only when GNU Make is used.
+#
+# - GNU Make will try to include 'gnu.mk'.
+# - NetBSD Make (bmake) will see '-include ' (empty) and do nothing as
+#   expected because the content of gnu.mk can only be parsed by GNU Make.
+# - The gnu.mk parses Make command line and builds the logic for the test-this
+#   rule.
+#
+-include $(_GNU_MAKE_ONLY_FILE)
+
+
+help:
+	@printf -- "\n\
+Execute dumb-jump Ert tests.\n\
+The following targets are supported:\n\
+\n\
+- make                       : same as 'make test'\n\
+- make install               : install all dependencies specified in Cask file\n\
+- make unit                  : execute all Ert tests\n\
+- make test                  : execute all Ert tests\n\
+- make test-this T1 [T2...]  : execute specified Ert test(s) T1, T2...\n\
+- make test-concurrent       : execute all Ert tests, but concurrently.\n\
+- make help                  : prints this help.\n\n\
+Notes:\n\
+- 'test-concurrent' shows # of skipped tests due to unavailability of a search tool, others do not.\n\
+- 'test-this' is only available when using GNU Make.\n\
+- Use 'test-this' to identify a set of tests by complete or partial names.\n\n"
+
+# ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -292,8 +292,20 @@ There are a lot of options for running the tests locally:
 requires [Cask](https://github.com/cask/cask) using your local emacs
 ```sh
 cd /path/to/dumb-jump
-cask
 make test
+```
+
+The first time you run this it will also run `cask` to
+setup your directory.
+
+##### Run a subset of tests
+is the same as before but use the `test-this` target followed by one or
+several full or partial test names.  For example, to run all tests that have 'clojure'
+or 'org' in their test function name do this:
+
+```sh
+cd /path/to/dumb-jump
+make test-this clojure org
 ```
 
 #### Concurrent

--- a/gnu.mk
+++ b/gnu.mk
@@ -1,0 +1,52 @@
+# MAKEFILE FILE: gnu.mk
+#
+# Purpose   : GNU Make compatible logic, conditionally included in Makefile.
+# ----------------------------------------------------------------------------
+
+# Special rule for: 'make test-this'
+# ----------------------------------
+#
+# When the first target is test-this, the following arguments on make command
+# line are interpreted as names of ERT test functions and make then issues a
+# cask exec ert-runner for those tests only.
+#
+# The following logic builds a properly formatted string in the TEST_NAMES
+# variable by first building a space-separated list of test names in the
+# TEST_NAMES_LIST variables and then replaces the spaces by the \| separator.
+# The special empty and space variables are first required to create a
+# variable that holds one space character. There must NOT be any trailing
+# spaces inside this file (and that should always be the case in Make files)!
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+#
+
+CASK ?= cask
+
+empty :=
+space := $(empty) $(empty)
+
+# If the first argument is "test-this" then execute the specified test(s).
+ifeq (test-this,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "test-this"
+  TEST_NAMES_LIST := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  TEST_NAMES := $(subst $(space),\|,$(TEST_NAMES_LIST))
+  # ...and turn them into do-nothing targets when there are some.
+ifneq ($(strip $(TEST_NAMES_LIST)),)
+   $(eval $(TEST_NAMES_LIST):;@:)
+endif
+endif
+
+
+.PHONY: test-this
+
+test-this: .cask
+ifeq ($(strip $(TEST_NAMES)),)
+	@printf -- "ERROR: No test names provided after test-this. Aborting.\n"
+	@exit 1
+else
+	${CASK} exec ert-runner -p "$(TEST_NAMES)"
+endif
+
+# ----------------------------------------------------------------------------


### PR DESCRIPTION
* The new .cask rule ensures that the .cask directory exists. if that directory does not exist, then the cask command is issued to create and populate it.
  - This is needed to be able to execute the Emacs Ert based tests, so the .cask rule is now added as a pre-requisite to several test rules.
  - It is no longer necessary to execute `cask` manually before executing `make test`; the make rule will run it if it was not done.

* Marked all targets, except the new `.cask` target, as `.PHONY` to prevent confusion with a file having the same name as a file or directory.

* Added a new rule: the `help` rule.  It displays information about local testing.

* Added a new rule: the `test-this` rule.
  - It is only available when using GNU Make.
  - The code is written to allow parsing by either GNU Make or by the NetBSD bmake.  When nusing bmake the 'test-this' rule will not be available, that rule is only available when GNU Make is used because the code is only compatible with GNU Make.
  - To allow parsing/execution of the remainder rules by bmake, the logic that is GNU make specific is isolated inside a new file: gnu.mk.  That file is included into Makefile by GNU make; the bmake will not include it, it may print a warning but will proceed anyway, and that's the goal.

    When using GNU make, it is now possible to execute a specific set of tests from the command line.  For example:

    ``` shell zsh% make test-this clojure cask exec ert-runner -p "clojure" Running 4 tests (2026-02-09 10:54:49-0500)

       passed  1/4  dumb-jump-go-clojure-asterisk-test
       passed  2/4  dumb-jump-go-clojure-no-asterisk-test
       passed  3/4  dumb-jump-go-clojure-no-question-mark-test
       passed  4/4  dumb-jump-go-clojure-question-mark-test

    Ran 4 tests, 4 results as expected (2026-02-09 10:54:49-0500)

    >0
    zsh% make test-this clojure t2 cask exec ert-runner -p "clojure\|t2" Running 7 tests (2026-02-09 10:55:01-0500)

       passed  1/7  dumb-jump-cpp-test2
       passed  2/7  dumb-jump-go-clojure-asterisk-test
       passed  3/7  dumb-jump-go-clojure-no-asterisk-test
       passed  4/7  dumb-jump-go-clojure-no-question-mark-test
       passed  5/7  dumb-jump-go-clojure-question-mark-test
       passed  6/7  dumb-jump-org-test2
       passed  7/7  dumb-jump-react-test2

    Ran 7 tests, 7 results as expected (2026-02-09 10:55:02-0500)

    >0
    ```

    It is also possible to pass the exact name of one or several test functions.

* Describe the new make rules in the Readme file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to run specific tests by partial name matching
  * Added help command displaying build system usage and options

* **Documentation**
  * Updated setup instructions for initial run with dependency execution
  * Added examples for running test subsets by name

* **Chores**
  * Improved build system tooling detection and compatibility
  * Enhanced test dependency management to ensure proper execution order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->