### PR TITLE
Fix remaining warnings in test code and data. Address issue #466.

### DIFF
--- a/test/data/fake-library/lib.el
+++ b/test/data/fake-library/lib.el
@@ -1,4 +1,4 @@
-
+;;; -*- lexical-binding: t -*-
 
 ;; for a fake lib +path in config file
 (defun func-in-lib (arg1 arg2)

--- a/test/data/proj2-elisp/fake.el
+++ b/test/data/proj2-elisp/fake.el
@@ -1,7 +1,7 @@
-;;; fake.el --- fake file for testing dumb-jump
+;;; fake.el --- fake file for testing dumb-jump -*- lexical-binding: t -*-
 
 (defun some-fake-function (blah)
-  (message "heyyy"))
+  (message "heyyy %s" blah))
 
 (defun another-fake-function (blah)
-  (message "heyyy again"))
+  (message "heyyy again, %s" blah))

--- a/test/data/proj2-elisp/fake2.el
+++ b/test/data/proj2-elisp/fake2.el
@@ -1,10 +1,10 @@
-;; a totally fake file for tests
+;; a totally fake file for tests -*- lexical-binding: t -*-
 
 (defun when-var-is-in-sig (my-arg2)
   (let* ((my-arg 22))
     (if (> my-arg2 my-arg)
         ""
-        (something-else my-arg2))))
+      (with-no-warnings (something-else my-arg2)))))
 
 (defun when-var-is-in-let ()
   (let* ((my-arg 11)
@@ -18,9 +18,9 @@
          (my-arg2 22)
          (their-my-arg2 22))
     (if (> my-arg2 my-arg)
-        ""
-        (when-var-is-in-sig my-arg2))))
+        (when-var-is-in-sig their-my-arg2)
+      (when-var-is-in-sig my-arg2))))
 
-(func-in-lib 1 2)
+(with-no-warnings (func-in-lib 1 2))
 
 ;; end of file

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -1246,7 +1246,7 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
     (with-current-buffer (find-file-noselect el-file t)
       (goto-char (point-min))
       (forward-line 23)
-      (forward-char 3)
+      (forward-char 19)
       (with-mock-forbidding-prompt
         (stub dumb-jump-rg-installed? => t)
         (mock (dumb-jump-goto-file-line * 4 7))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,3 +1,4 @@
+;;; -*- lexical-binding: t -*-
 
 (require 'ert)
 (require 'undercover)


### PR DESCRIPTION
* All Emacs Lisp test data files are now explicitly declared using lexical-binding and modified to byte compile without warnings.

  - A modification of test/data/fake2.el caused a change of coordinates inside `dumb-jump-go-include-lib-test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cursor positioning for improved test accuracy.

* **Refactor**
  * Added lexical-binding configuration headers to enhance code evaluation scope and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->