### PR TITLE
Project.el support

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -3621,12 +3621,13 @@ Return a directory name without the trailing slash."
          (project-el-root
           (when (and (null dumb-jump-project)
                      dir
-                     (fboundp 'project-current)
-                     (fboundp 'project-root))
+                     (fboundp 'project-current))
             (let ((default-directory dir))
               (let ((proj (ignore-errors (project-current nil))))
                 (when proj
-                  (project-root proj)))))))
+                  (if (fboundp 'project-root)
+                      (project-root proj)
+                    (car (project-roots proj)))))))))
     (directory-file-name
      (expand-file-name
       (or dumb-jump-project

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -665,8 +665,8 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
 (ert-deftest dumb-jump-find-proj-root-project-el-override-test ()
   "When `dumb-jump-project' is set, it should take priority over project.el."
   (with-mock
-    (stub project-current => '(vc Git "/tmp/fake-project/"))
-    (stub project-root => "/tmp/fake-project/")
+    (stub project-current => (error "project-current should not be called"))
+    (stub project-root => (error "project-root should not be called"))
     (let* ((dumb-jump-project "/tmp/explicit-override")
            (found-project (dumb-jump-get-project-root "/tmp/fake-project/src/foo.c")))
       (should (string= found-project "/tmp/explicit-override")))))


### PR DESCRIPTION
Potentially addresses #470 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Prioritizes Emacs project.el for project-root detection while preserving existing fallback order and honoring explicit overrides.

* **Tests**
  * Added tests verifying project-root resolution with project.el and that explicit project overrides take precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->