### PR TITLE
Remove redundant config loading in dumb-jump-fetch-results

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -3894,7 +3894,7 @@ For instance, remove clojure namespace prefix."
                             dumb-jump-language-file-exts)))
     (mapcar (lambda (it) (plist-get it :language)) found)))
 
-(defun dumb-jump-fetch-results (cur-file proj-root lang _config
+(defun dumb-jump-fetch-results (cur-file proj-root lang config
                                          &optional entered-name)
   "Search for symbol in ENTERED-NAME or symbol at point.
 
@@ -3914,9 +3914,6 @@ The returned property list has the following members:
 - :file    : string: file name
 - :root    : string: project root."
   (let* ((cur-line-num (line-number-at-pos))
-         (proj-config (dumb-jump-get-config proj-root))
-         (config (when (string-suffix-p ".dumbjump" proj-config)
-                   (dumb-jump-read-config proj-root proj-config)))
          (found-symbol (or entered-name (dumb-jump-get-point-symbol)))
          (look-for (dumb-jump-process-symbol-by-lang lang found-symbol))
          (pt-ctx (if entered-name


### PR DESCRIPTION
## Summary
- Fixes #336
- `dumb-jump-fetch-results` was re-reading the project config from disk even though both callers (`dumb-jump-get-results` and `dumb-jump-fetch-file-results`) already compute and pass it in
- Removed the unused `proj-config` and `config` bindings from the `let*` form and use the passed-in `config` parameter instead

## Test plan
- [x] Existing `dumb-jump-fetch-results-test` continues to pass (it calls via `dumb-jump-fetch-file-results` which passes config)
- [ ] Verify jump-to-definition works in a project with a `.dumbjump` config file
- [ ] Verify jump-to-definition works in a project without a `.dumbjump` config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated core function signature to simplify parameter handling and improve consistency. Integration points may require adjustments to align with the new interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->