### PR TITLE
convert absolute exclude paths to relative for grep (closes #462)

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -5066,7 +5066,13 @@ The arguments are:
          (case-args (if (member lang dumb-jump--case-insensitive-languages)
                         " --ignore-case"
                       ""))
-         (exclude-args (dumb-jump-arg-joiner "--exclude-dir" exclude-paths))
+         (proj-dir (file-name-as-directory proj))
+         (exclude-args (dumb-jump-arg-joiner
+                        "--exclude-dir"
+                        (mapcar
+                         (lambda (it)
+                           (dumb-jump--replace proj-dir "" it))
+                         exclude-paths)))
          (include-args (dumb-jump-get-ext-includes lang))
          (regex-args (dumb-jump-arg-joiner "-e" filled-regexes)))
     (if (null regexes)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -454,6 +454,23 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
     ;; the point context being passed is ignored so ALL should return
     (should (string= expected  (dumb-jump-generate-grep-command "tester" "blah.el" "." regexes "" nil)))))
 
+(ert-deftest dumb-jump-generate-grep-command-exclude-test ()
+  "Test that grep exclude paths are converted from absolute to relative (#462)."
+  (let* ((system-type 'darwin)
+         (regexes (dumb-jump-get-contextual-regexes "elisp" nil 'grep))
+         (expected-regexes (mapcar (lambda (it) (concat " -e " (shell-quote-argument it)))
+                                   (dumb-jump--elisp-expected-regexps 'grep)))
+         (expected (concat
+                    "LANG=C grep -REn --exclude-dir this/is/excluded"
+                    " --include \\*.el --include \\*.el.gz"
+                    (string-join expected-regexes "")
+                    " /path/to/proj-root")))
+    (should (string= expected
+                     (dumb-jump-generate-grep-command
+                      "tester" "blah.el" "/path/to/proj-root"
+                      regexes "elisp"
+                      '("/path/to/proj-root/this/is/excluded"))))))
+
 (ert-deftest dumb-jump-generate-bad-grep-command-test ()
     (should (string-blank-p (dumb-jump-generate-grep-command "tester" "blah.el" "." nil "" (list "skaldjf")))))
 


### PR DESCRIPTION
## Summary
- GNU grep's `--exclude-dir` requires relative paths, but dumb-jump was passing absolute paths expanded from `.dumbjump` config
- Strip the project root prefix in `dumb-jump-generate-grep-command`, matching how ag and rg generators already handle this
- Added `dumb-jump-generate-grep-command-exclude-test` to verify the fix

## Test plan
- [x] All existing grep command generation tests pass
- [x] New exclude path test verifies absolute-to-relative conversion
- [x] Full test suite run in Docker (Emacs 29.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exclusion path handling in search commands to convert absolute paths to relative paths relative to the project root, enhancing compatibility and consistency across different search backends.

* **Tests**
  * Added new test cases to validate exclude directory functionality in grep-based search commands, ensuring proper relative path translation and command construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->