### PR TITLE
Quote project paths to fix unicode path handling (#155/#158)

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -4880,14 +4880,14 @@ The arguments are:
          (regex-args (shell-quote-argument (dumb-jump--join "|" filled-regexes))))
     (if (null regexes)
         ""
-      (dumb-jump-concat-command cmd exclude-args "--" regex-args proj))))
+      (dumb-jump-concat-command cmd exclude-args "--" regex-args (shell-quote-argument proj)))))
 
 ;; --
 (defun dumb-jump-get-git-grep-files-matching-symbol (symbol proj-root)
   "Return a list of file names in PROJ-ROOT holding the literal SYMBOL.
 Search for matching files using git grep."
   (let* ((cmd (format "git grep --full-name -F -c %s %s"
-                      (shell-quote-argument symbol) proj-root))
+                      (shell-quote-argument symbol) (shell-quote-argument proj-root)))
          (result (dumb-jump--trim (shell-command-to-string cmd)))
          ;; result: '\n\ separated lines of: "path-name:count"
          ;; extract the name of files and return them in a list.
@@ -4954,7 +4954,7 @@ The arguments are:
          (regex-args (shell-quote-argument (dumb-jump--join "|" filled-regexes))))
     (if (null regexes)
         ""
-      (dumb-jump-concat-command cmd exclude-args regex-args proj))))
+      (dumb-jump-concat-command cmd exclude-args regex-args (shell-quote-argument proj)))))
 
 ;; --
 (defun dumb-jump-generate-rg-command (look-for
@@ -4994,7 +4994,7 @@ The arguments are:
          (regex-args (shell-quote-argument (dumb-jump--join "|" filled-regexes))))
     (if (null regexes)
         ""
-      (dumb-jump-concat-command cmd exclude-args "--" regex-args proj))))
+      (dumb-jump-concat-command cmd exclude-args "--" regex-args (shell-quote-argument proj)))))
 
 (defun dumb-jump-generate-git-grep-command (look-for
                                             cur-file proj
@@ -5079,7 +5079,7 @@ The arguments are:
         ""
       (dumb-jump-concat-command cmd dumb-jump-grep-args
                                 case-args exclude-args
-                                include-args regex-args proj))))
+                                include-args regex-args (shell-quote-argument proj)))))
 
 (defun dumb-jump-generate-gnu-grep-command (look-for
                                             cur-file proj
@@ -5115,7 +5115,7 @@ The arguments are:
         ""
       (dumb-jump-concat-command cmd dumb-jump-gnu-grep-args
                                 case-args exclude-args
-                                include-args regex-args proj))))
+                                include-args regex-args (shell-quote-argument proj)))))
 
 ;; ---------------------------------------------------------------------------
 

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -258,7 +258,7 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
           (concat
            "ag --nocolor --nogroup --elisp --ignore-dir this/is/excluded -- "
            (shell-quote-argument expected-regexes)
-           " /path/to/proj-root")))
+           " " (shell-quote-argument "/path/to/proj-root"))))
     (should (string= expected
                      (dumb-jump-generate-ag-command
                       "tester" "blah.el" "/path/to/proj-root"
@@ -274,7 +274,7 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
           ;; NOTE no "--elisp" and the `-G` arg is new
           (concat "ag --nocolor --nogroup -G '(/path/to/proj-root/blah.el)' "
                   (shell-quote-argument expected-regexes)
-                  " /path/to/proj-root")))
+                  " " (shell-quote-argument "/path/to/proj-root"))))
     (with-mock
       (mock
        (dumb-jump-get-git-grep-files-matching-symbol-as-ag-arg * *) => "'(/path/to/proj-root/blah.el)'")
@@ -294,7 +294,7 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
           ;; NOTE no "--elisp" and the `-G` arg is new
           (concat "ag --nocolor --nogroup -G '(/path/to/proj-root/blah.el)' --ignore-dir this/is/excluded "
                   (shell-quote-argument expected-regexes)
-                  " /path/to/proj-root")))
+                  " " (shell-quote-argument "/path/to/proj-root"))))
     (with-mock
       (mock (dumb-jump-get-git-grep-files-matching-symbol-as-ag-arg * *) => "'(/path/to/proj-root/blah.el)'")
       (should (string= expected
@@ -323,11 +323,46 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
          (expected
           (concat "rg --color never --no-heading --line-number -U --pcre2 --type elisp -g \\!this/is/excluded -- "
                   (shell-quote-argument expected-regexes)
-                  " /path/to/proj-root")))
+                  " " (shell-quote-argument "/path/to/proj-root"))))
     (should (string= expected
                      (dumb-jump-generate-rg-command
                       "tester" "blah.el" "/path/to/proj-root" regexes "elisp"
                       '("/path/to/proj-root/this/is/excluded"))))))
+
+(ert-deftest dumb-jump-generate-ag-command-unicode-path-test ()
+  "Test that ag command correctly quotes unicode characters in project path."
+  (let* ((regexes (dumb-jump-get-contextual-regexes "elisp" nil 'ag))
+         (proj "/path/to/проект")
+         (expected-regexes
+          (mapconcat #'identity
+                     (dumb-jump--elisp-expected-regexps 'ag)
+                     "|"))
+         (expected
+          (concat
+           "ag --nocolor --nogroup --elisp -- "
+           (shell-quote-argument expected-regexes)
+           " " (shell-quote-argument proj))))
+    (should (string= expected
+                     (dumb-jump-generate-ag-command
+                      "tester" "blah.el" proj
+                      regexes "elisp" nil)))))
+
+(ert-deftest dumb-jump-generate-rg-command-unicode-path-test ()
+  "Test that rg command correctly quotes unicode characters in project path."
+  (let* ((regexes (dumb-jump-get-contextual-regexes "elisp" nil 'rg))
+         (proj "/path/to/проект")
+         (expected-regexes
+          (mapconcat #'identity
+                     (dumb-jump--elisp-expected-regexps 'rg)
+                     "|"))
+         (expected
+          (concat "rg --color never --no-heading --line-number -U --pcre2 --type elisp -- "
+                  (shell-quote-argument expected-regexes)
+                  " " (shell-quote-argument proj))))
+    (should (string= expected
+                     (dumb-jump-generate-rg-command
+                      "tester" "blah.el" proj
+                      regexes "elisp" nil)))))
 
 (ert-deftest dumb-jump-generate-git-grep-command-no-ctx-test ()
   (let* ((regexes (dumb-jump-get-contextual-regexes "elisp" nil 'git-grep))
@@ -439,7 +474,7 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
            (regexes (dumb-jump-get-contextual-regexes "elisp" ctx-type 'grep))
            (expected-regexes (mapcar (lambda (it) (concat " -e " (shell-quote-argument it)))
                                      (dumb-jump--elisp-expected-regexps 'grep 'elisp-functions)))
-           (expected (concat "grep -REn" (string-join expected-regexes "") " .")))
+           (expected (concat "grep -REn" (string-join expected-regexes "") " " (shell-quote-argument "."))))
       (should (string= expected  (dumb-jump-generate-grep-command "tester" "blah.el" "." regexes "" nil))))))
 
 (ert-deftest dumb-jump-generate-grep-command-with-ctx-but-ignored-test ()


### PR DESCRIPTION
## Summary
- Apply `shell-quote-argument` to the `proj` directory argument in all 6 command generation functions (`generate-ag-command`, `generate-rg-command`, `generate-git-grep-plus-ag-command`, `generate-grep-command`, `generate-gnu-grep-command`, `get-git-grep-files-matching-symbol`)
- Fixes shell commands failing when project paths contain unicode characters (e.g., UTF-8-HFS decomposed paths on macOS)
- Updates existing tests to match new quoting behavior and adds 2 new unicode path tests using Cyrillic characters

Closes #155, closes #158

## Test plan
- [x] All 196 existing tests pass (`make unit`)
- [x] New `dumb-jump-generate-ag-command-unicode-path-test` passes
- [x] New `dumb-jump-generate-rg-command-unicode-path-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search functionality to properly handle project paths containing spaces or special characters. All search commands now correctly quote project paths, preventing errors when searching in directories with non-standard names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->