### PR TITLE
add buffer-local dumb-jump-local-mode (closes #327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,15 @@ interface. These are:
 * `dumb-jump-confirm-jump-to-modified-file`
 
 The minor mode `dumb-jump-mode` binds a few of these commands by
-default.
+default and enables them globally.
+
+If you want to enable dumb-jump in specific major modes only, use
+`dumb-jump-local-mode` instead:
+
+```elisp
+(add-hook 'python-mode-hook #'dumb-jump-local-mode)
+(add-hook 'rust-mode-hook #'dumb-jump-local-mode)
+```
 
 ## Why?
 

--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -5187,6 +5187,15 @@ they are not covered by ripgrep's built-in type definitions."
       results)))
 
 ;;;###autoload
+(define-minor-mode dumb-jump-local-mode
+  "Buffer-local minor mode for jumping to variable and function definitions.
+Use this to selectively enable dumb-jump in specific major modes, e.g.:
+  (add-hook \\='python-mode-hook #\\='dumb-jump-local-mode)
+For enabling globally, use `dumb-jump-mode' instead."
+  :global nil
+  :keymap dumb-jump-mode-map)
+
+;;;###autoload
 (define-minor-mode dumb-jump-mode
   "Minor mode for jumping to variable and function definitions."
   ;; Note: independent of the Emacs xref interface.


### PR DESCRIPTION
## Summary
- Adds `dumb-jump-local-mode`, a buffer-local minor mode so users can selectively enable dumb-jump for specific major modes via hooks (e.g. `(add-hook 'python-mode-hook #'dumb-jump-local-mode)`)
- Keeps the existing global `dumb-jump-mode` unchanged for full backward compatibility
- Updates README with usage examples

## Test plan
- [ ] Verify `dumb-jump-mode` still works globally as before
- [ ] Verify `dumb-jump-local-mode` enables keybindings only in the current buffer
- [ ] Verify adding `dumb-jump-local-mode` to a major mode hook activates it only in that mode's buffers

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to enable dumb-jump in specific major modes via a local mode variant.
  * Global dumb-jump mode now enabled by default.

* **Documentation**
  * Added configuration examples for enabling dumb-jump in Python and Rust modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->