### PR TITLE
Fix searcher ordering: auto-fallback + expand language rule support

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2140,7 +2140,8 @@ If nil add also the language type of current src block."
     (:language "haskell" :type "module"
            :supports ("ag" "rg" "grep" "git-grep")
            :regex "^module\\s+JJJ\\s+"
-           :tests ("module test (exportA, exportB) where"))
+           :tests ("module test (exportA, exportB) where")
+           :not ("-- module test" "import test"))
 
                                         ; TODO Doesn't support any '=' in arguments. E.g. 'foo A{a = b,..} = bar'.
     (:language "haskell" :type "top level function"
@@ -3992,16 +3993,23 @@ The returned property list has the following members:
          (regexes (dumb-jump-get-contextual-regexes lang ctx-type searcher))
 
          ;; If selected searcher has no rules for this language, try alternatives.
-         ;; Respect dumb-jump-force-searcher (don't override explicit user choice).
+         ;; Only block fallback when dumb-jump-force-searcher is a direct
+         ;; searcher symbol.  When it's a function or directory list that
+         ;; didn't match this project, the auto-selected searcher should
+         ;; still be eligible for fallback.
          (_alt-searcher
           (when (and (null regexes)
-                     (not dumb-jump-force-searcher))
+                     (not (memq dumb-jump-force-searcher
+                                '(ag rg grep gnu-grep git-grep
+                                     git-grep-plus-ag))))
             (let ((alt (seq-find
                         (lambda (s)
                           (and (not (eq s searcher))
-                               (funcall (plist-get
-                                         (dumb-jump-generators-by-searcher s)
-                                         :installed))
+                               (if (eq s 'gnu-grep)
+                                   (eq (dumb-jump-grep-installed?) 'gnu)
+                                 (funcall (plist-get
+                                           (dumb-jump-generators-by-searcher s)
+                                           :installed)))
                                (dumb-jump-get-rules-by-language lang s)))
                         '(ag rg git-grep gnu-grep grep))))
               (when alt

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -2014,35 +2014,53 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
     (should (seq-find (lambda (r) (string= (plist-get r :type) "typeclass")) rules))))
 
 (ert-deftest dumb-jump-get-rules-by-language-haskell-grep ()
-  "Haskell portable rules should be available for grep searcher."
+  "Haskell portable rules should be available for grep searcher.
+Non-portable rules (multiline/lookahead) should not be."
   (let ((rules (dumb-jump-get-rules-by-language "haskell" 'grep)))
     (should (> (length rules) 0))
+    ;; Portable rules should be present
     (should (seq-find (lambda (r) (string= (plist-get r :type) "module")) rules))
     (should (seq-find (lambda (r) (string= (plist-get r :type) "type-like")) rules))
-    (should (seq-find (lambda (r) (string= (plist-get r :type) "typeclass")) rules))))
+    (should (seq-find (lambda (r) (string= (plist-get r :type) "typeclass")) rules))
+    ;; Non-portable rules should NOT be present
+    (should-not (seq-find (lambda (r) (string= (plist-get r :type) "top level function")) rules))
+    (should-not (seq-find (lambda (r) (string= (plist-get r :type) "(data)type constructor 1")) rules))
+    (should-not (seq-find (lambda (r) (string= (plist-get r :type) "data/newtype record field")) rules))))
 
 (ert-deftest dumb-jump-searcher-fallback-when-no-rules ()
-  "When selected searcher has no rules for a language, fall back to one that does."
+  "When selected searcher has no rules for a language, fall back to one that does.
+Exercises the actual fallback path in dumb-jump-fetch-results."
   (let ((dumb-jump-force-searcher nil)
-        (dumb-jump-prefer-searcher nil)
-        ;; Simulate: only grep is available, but the language has no grep rules.
-        ;; ag is also available and has rules.
+        ;; Prefer rg so it's selected initially (not ag).
+        (dumb-jump-prefer-searcher 'rg)
         (dumb-jump--ag-installed? t)
-        (dumb-jump--rg-installed? nil)
+        (dumb-jump--rg-installed? t)
         (dumb-jump--grep-installed? nil)
-        (dumb-jump--git-grep-installed? nil))
-    ;; Create a fake language rule that only supports ag
-    (let ((dumb-jump-find-rules
-           (list '(:language "fakelang" :type "function"
-                   :supports ("ag")
-                   :regex "def\\s+JJJ\\b"
-                   :tests ("def test")))))
-      ;; With grep selected (fallback since nothing else "installed"),
-      ;; fakelang has no grep rules, so it should fall back to ag.
-      (let* ((regexes-grep (dumb-jump-get-rules-by-language "fakelang" 'grep))
-             (regexes-ag (dumb-jump-get-rules-by-language "fakelang" 'ag)))
-        (should (null regexes-grep))
-        (should (= (length regexes-ag) 1))))))
+        (dumb-jump--git-grep-installed? nil)
+        ;; fakelang only has ag rules — rg has no rules for it.
+        (dumb-jump-find-rules
+         (list '(:language "fakelang" :type "function"
+                 :supports ("ag")
+                 :regex "def\\s+JJJ\\b"
+                 :tests ("def test"))))
+        (used-generate-fn nil))
+    ;; Verify rg is selected but has no rules for fakelang
+    (should (eq (dumb-jump-selected-grep-variant) 'rg))
+    (should (null (dumb-jump-get-rules-by-language "fakelang" 'rg)))
+    (should (dumb-jump-get-rules-by-language "fakelang" 'ag))
+    ;; Call dumb-jump-fetch-results and verify the fallback switches to ag
+    (with-temp-buffer
+      (insert "def test")
+      (goto-char 5)
+      (let ((buffer-file-name "/tmp/fake.fakelang"))
+        (noflet ((dumb-jump-run-command
+                  (look-for proj regexes lang exclude-paths
+                            cur-file cur-line-num parse-fn generate-fn)
+                  (setq used-generate-fn generate-fn)
+                  nil))
+          (dumb-jump-fetch-results "/tmp/fake.fakelang" "/tmp" "fakelang" nil)
+          ;; The fallback should have switched from rg to ag
+          (should (eq used-generate-fn 'dumb-jump-generate-ag-command)))))))
 
 ;; This test makes sure that if the `cur-file' is absolute but results are relative, then it must
 ;; still find and sort results correctly.


### PR DESCRIPTION
## Summary

Fixes #376 — when the selected searcher had no rules for the current language (e.g. Haskell only supported `ag`), users got zero language-specific results and fell through to a dumb fallback regex.

Two-pronged fix:

- **Expand `:supports` on language rules** where the regex is portable across searchers:
  - **Haskell**: add `rg` to all 6 rules; add `grep`/`git-grep` to the 3 portable rules (module, type-like, typeclass). The 3 complex rules (multiline/lookahead) remain ag+rg only.
  - **OCaml**: add `grep`/`git-grep` to all 6 rules
  - **FSharp**: add `rg` to all 3 rules
  - **Coq**: add `grep` to all 8 rules
- **Auto-fallback searcher logic** in `dumb-jump-fetch-results`: when the selected searcher has no rules for the current language, automatically try alternatives in order (ag → rg → git-grep → gnu-grep → grep). Respects `dumb-jump-force-searcher`.

## Test plan

- [x] All 209 existing tests pass
- [x] New tests verify Haskell rules are available for rg and grep searchers
- [x] New test verifies the auto-fallback mechanism
- [ ] Manual: open a Haskell file with only `rg` installed (no `ag`), verify `dumb-jump-go` finds definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fallback search tool logic that automatically tries alternative backends when the preferred tool lacks language-specific rules, improving search robustness.

* **Bug Fixes**
  * Broadened search backend support across multiple languages so more tools are recognized for symbol discovery.

* **Tests**
  * Added tests validating language rule retrieval and searcher-fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->