### PR TITLE
Warn when ripgrep PCRE2 is not available

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -4859,7 +4859,7 @@ The parameters are:
     (dumb-jump-debug-message cmd)
     (setq rawresults (shell-command-to-string cmd))
     (dumb-jump-debug-message rawresults)
-    (when (string-match-p "PCRE2 is not available" rawresults)
+    (when (string-match-p "^PCRE2 is not available" rawresults)
       (dumb-jump-message "dumb-jump: Ripgrep PCRE2 support is not available. Install ripgrep with PCRE2 support or customize `dumb-jump-rg-search-args' to remove \"--pcre2\".")
       (dumb-jump-env-problem "Ripgrep PCRE2 support is not available in the current build."))
     (when (and (string-blank-p rawresults)

--- a/test/dumb-jump-test.el
+++ b/test/dumb-jump-test.el
@@ -664,6 +664,27 @@ VARIANT must be one of: ag, rg, grep, gnu-grep, git-grep, or git-grep-plus-ag."
         (should (cl-some (lambda (p) (string-match-p "PCRE2" p))
                          dumb-jump--detected-env-problems))))))
 
+(ert-deftest dumb-jump-run-cmd-pcre2-warning-no-false-positive-test ()
+  "Test that a search hit containing the PCRE2 error text does not trigger the warning."
+  (let ((dumb-jump--detected-env-problems nil)
+        (warned nil))
+    (cl-letf (((symbol-function 'shell-command-to-string)
+               (lambda (_cmd) "src/foo.c:42:// PCRE2 is not available in this build"))
+              ((symbol-function 'dumb-jump-message)
+               (lambda (str &rest _args)
+                 (when (string-match-p "PCRE2" str)
+                   (setq warned t)))))
+      (let* ((generate-fn (lambda (&rest _args) "rg --pcre2 test"))
+             (parse-fn (lambda (raw _file _line)
+                         (unless (string-blank-p raw)
+                           (list (list :context "PCRE2 is not available"
+                                       :path "src/foo.c"
+                                       :line 42)))))
+             (results (dumb-jump-run-command "PCRE2" "/tmp" '("regex") "c" "" "test.c" 1
+                                             parse-fn generate-fn)))
+        (should-not warned)
+        (should (null dumb-jump--detected-env-problems))))))
+
 (ert-deftest dumb-jump-find-proj-root-test ()
   (let* ((js-file (f-join test-data-dir-proj1 "src" "js"))
          (found-project (dumb-jump-get-project-root js-file)))


### PR DESCRIPTION
## Summary
- Detects PCRE2 error messages in ripgrep output during command execution (closes #303)
- Shows a clear warning message directing users to install rg with PCRE2 or customize `dumb-jump-rg-search-args`
- Records the issue in `dumb-jump--detected-env-problems` for diagnostics

## Context
When ripgrep is built without PCRE2 support and used with `--pcre2` (the default), it returns "PCRE2 is not available in this build of ripgrep". Previously this was silently swallowed, leading to confusing "not found" messages. This is especially relevant when `dumb-jump-force-searcher` is set to `'rg`, which bypasses the installation check that normally detects missing PCRE2.

## Test plan
- [x] Added `dumb-jump-run-cmd-pcre2-warning-test` to verify warning is displayed and env problem is recorded
- [x] All 223 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime check for Ripgrep PCRE2 support; if missing, users see a clear notification about limited search behavior.

* **Tests**
  * Added tests ensuring a PCRE2-missing warning is emitted and recorded when ripgrep reports PCRE2 absence.
  * Added a test ensuring no false-positive warnings when search hits contain PCRE2-related text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->