### PR TITLE
Fix stray colon in Elixir defprotocol rule causing severe slowdown

### DIFF
--- a/dumb-jump.el
+++ b/dumb-jump.el
@@ -2537,7 +2537,7 @@ If nil add also the language type of current src block."
                    "defmodule Foo.Bar.test do"))
 
     (:language "elixir" :type "module"
-           :supports ("ag" "grep" "rg" "git-grep") :
+           :supports ("ag" "grep" "rg" "git-grep")
            :regex "defprotocol\\s+(\\w+\\.)*JJJ\\s+"
            :tests ("defprotocol test do"
                    "defprotocol Foo.Bar.test do"))


### PR DESCRIPTION
A trailing `:` in :supports broke plist alignment, so :regex parsed as nil. Joined with "|", the nil produced a trailing empty alternative that matched every line under --pcre2, making xref-find-definitions very slow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a syntax error in the Elixir module detection rule to ensure proper pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->